### PR TITLE
Fix invalid cudaFree in GPU repeat_elements path

### DIFF
--- a/temporal_random_walk/src/utils/utils.cuh
+++ b/temporal_random_walk/src/utils/utils.cuh
@@ -68,7 +68,7 @@ HOST inline DataBlock<int> repeat_elements(const int* arr, const size_t input_si
     #ifdef HAS_CUDA
     if (use_gpu) {
         // Copy vector data to device first
-        int* d_arr;
+        int* d_arr = nullptr;
         allocate_memory(&d_arr, input_size, true);
         CUDA_CHECK_AND_CLEAR(cudaMemcpy(d_arr, arr, input_size * sizeof(int), cudaMemcpyHostToDevice));
 


### PR DESCRIPTION
### Motivation
- Prevent `cudaErrorInvalidValue` from occurring when `allocate_memory` attempts to free an uninitialized temporary device pointer used by `repeat_elements` in the last-batch GPU path.

### Description
- Initialize the temporary device pointer with `int* d_arr = nullptr;` in `repeat_elements(const int* arr, const size_t input_size, int times, const bool use_gpu)` to avoid passing a garbage pointer into `allocate_memory` in `temporal_random_walk/src/utils/utils.cuh`.
- No other functional changes were made.

### Testing
- Ran `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` to configure a debug build, which failed due to missing `TBB` (`TBBConfig.cmake`), so a full build and test suite run could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd1027668483329c40559eb31f2bda)