### PR TITLE
Replace raw pointers with CudaBuffer RAII wrapper

### DIFF
--- a/temporal_random_walk/py_interface/_temporal_random_walk.cu
+++ b/temporal_random_walk/py_interface/_temporal_random_walk.cu
@@ -253,7 +253,7 @@ PYBIND11_MODULE(_temporal_random_walk, m)
             if (node_feature_store == nullptr ||
                 node_feature_store->node_feature_dim == 0 ||
                 node_feature_store->max_node_id < 0 ||
-                node_feature_store->node_features == nullptr) {
+                !node_feature_store->node_features) {
                 return py::array_t<float>(
                     py::array::ShapeContainer{0, 0},
                     py::array::StridesContainer{0, 0});
@@ -270,7 +270,7 @@ PYBIND11_MODULE(_temporal_random_walk, m)
 
             const size_t total_values = static_cast<size_t>(num_rows) * static_cast<size_t>(feature_dim);
             std::copy_n(
-                node_feature_store->node_features,
+                node_feature_store->node_features.data(),
                 total_values,
                 static_cast<float*>(dense_node_features.request().ptr));
 

--- a/temporal_random_walk/py_interface/_temporal_random_walk.cu
+++ b/temporal_random_walk/py_interface/_temporal_random_walk.cu
@@ -328,21 +328,21 @@ PYBIND11_MODULE(_temporal_random_walk, m)
                 );
 
                 py::object edge_features_array = py::none();
-                if (walks_with_edge_features.feature_dim > 0 && walks_with_edge_features.walk_edge_features != nullptr) {
+                if (walks_with_edge_features.feature_dim > 0 && walks_with_edge_features.walk_edge_features) {
                     const auto num_walks = static_cast<ssize_t>(walk_set.num_walks);
                     const ssize_t edges_per_walk = static_cast<ssize_t>(std::max(0, max_walk_len - 1));
                     const auto feature_dim = static_cast<ssize_t>(walks_with_edge_features.feature_dim);
 
+                    float* const released_features = walks_with_edge_features.walk_edge_features.release();
                     edge_features_array = py::array_t<float>(
                         py::array::ShapeContainer{num_walks, edges_per_walk, feature_dim},
                         py::array::StridesContainer{
                             static_cast<ssize_t>(sizeof(float) * edges_per_walk * feature_dim),
                             static_cast<ssize_t>(sizeof(float) * feature_dim),
                             static_cast<ssize_t>(sizeof(float))},
-                        walks_with_edge_features.walk_edge_features,
-                        py::capsule(walks_with_edge_features.walk_edge_features, [](void* p) { std::free(p); })
+                        released_features,
+                        py::capsule(released_features, [](void* p) { std::free(p); })
                     );
-                    walks_with_edge_features.walk_edge_features = nullptr;
                 }
 
                 walk_set.owns_data = false;
@@ -425,21 +425,21 @@ PYBIND11_MODULE(_temporal_random_walk, m)
                 );
 
                 py::object edge_features_array = py::none();
-                if (walks_with_edge_features.feature_dim > 0 && walks_with_edge_features.walk_edge_features != nullptr) {
+                if (walks_with_edge_features.feature_dim > 0 && walks_with_edge_features.walk_edge_features) {
                     const auto num_walks = static_cast<ssize_t>(walk_set.num_walks);
                     const ssize_t edges_per_walk = static_cast<ssize_t>(std::max(0, max_walk_len - 1));
                     const auto feature_dim = static_cast<ssize_t>(walks_with_edge_features.feature_dim);
 
+                    float* const released_features = walks_with_edge_features.walk_edge_features.release();
                     edge_features_array = py::array_t<float>(
                         py::array::ShapeContainer{num_walks, edges_per_walk, feature_dim},
                         py::array::StridesContainer{
                             static_cast<ssize_t>(sizeof(float) * edges_per_walk * feature_dim),
                             static_cast<ssize_t>(sizeof(float) * feature_dim),
                             static_cast<ssize_t>(sizeof(float))},
-                        walks_with_edge_features.walk_edge_features,
-                        py::capsule(walks_with_edge_features.walk_edge_features, [](void* p) { std::free(p); })
+                        released_features,
+                        py::capsule(released_features, [](void* p) { std::free(p); })
                     );
-                    walks_with_edge_features.walk_edge_features = nullptr;
                 }
 
                 walk_set.owns_data = false;
@@ -527,21 +527,21 @@ PYBIND11_MODULE(_temporal_random_walk, m)
                 );
 
                 py::object edge_features_array = py::none();
-                if (walks_with_edge_features.feature_dim > 0 && walks_with_edge_features.walk_edge_features != nullptr) {
+                if (walks_with_edge_features.feature_dim > 0 && walks_with_edge_features.walk_edge_features) {
                     const auto num_walks = static_cast<ssize_t>(walk_set.num_walks);
                     const ssize_t edges_per_walk = static_cast<ssize_t>(std::max(0, max_walk_len - 1));
                     const auto feature_dim = static_cast<ssize_t>(walks_with_edge_features.feature_dim);
 
+                    float* const released_features = walks_with_edge_features.walk_edge_features.release();
                     edge_features_array = py::array_t<float>(
                         py::array::ShapeContainer{num_walks, edges_per_walk, feature_dim},
                         py::array::StridesContainer{
                             static_cast<ssize_t>(sizeof(float) * edges_per_walk * feature_dim),
                             static_cast<ssize_t>(sizeof(float) * feature_dim),
                             static_cast<ssize_t>(sizeof(float))},
-                        walks_with_edge_features.walk_edge_features,
-                        py::capsule(walks_with_edge_features.walk_edge_features, [](void* p) { std::free(p); })
+                        released_features,
+                        py::capsule(released_features, [](void* p) { std::free(p); })
                     );
-                    walks_with_edge_features.walk_edge_features = nullptr;
                 }
 
                 walk_set.owns_data = false;

--- a/temporal_random_walk/src/common/cuda_buffer.cuh
+++ b/temporal_random_walk/src/common/cuda_buffer.cuh
@@ -1,0 +1,77 @@
+#ifndef CUDA_BUFFER_CUH
+#define CUDA_BUFFER_CUH
+
+#include <cstddef>
+#include <utility>
+
+#include "macros.cuh"
+#include "memory.cuh"
+
+// Move-only RAII wrapper over a host- or device-allocated buffer.
+// Frees with cudaFree when use_gpu is true, with free() otherwise.
+// Designed to replace raw T* members paired with manual allocate_memory /
+// clear_memory calls and owns_* flags.
+template <typename T>
+class CudaBuffer {
+public:
+    HOST CudaBuffer() noexcept = default;
+
+    HOST CudaBuffer(const size_t size, const bool use_gpu)
+        : size_(size), use_gpu_(use_gpu) {
+        if (size_ > 0) {
+            allocate_memory(&ptr_, size_, use_gpu_);
+        }
+    }
+
+    HOST ~CudaBuffer() { reset(); }
+
+    CudaBuffer(const CudaBuffer&) = delete;
+    CudaBuffer& operator=(const CudaBuffer&) = delete;
+
+    HOST CudaBuffer(CudaBuffer&& other) noexcept
+        : ptr_(other.ptr_), size_(other.size_), use_gpu_(other.use_gpu_) {
+        other.ptr_ = nullptr;
+        other.size_ = 0;
+    }
+
+    HOST CudaBuffer& operator=(CudaBuffer&& other) noexcept {
+        if (this != &other) {
+            reset();
+            ptr_ = other.ptr_;
+            size_ = other.size_;
+            use_gpu_ = other.use_gpu_;
+            other.ptr_ = nullptr;
+            other.size_ = 0;
+        }
+        return *this;
+    }
+
+    HOST void reset() noexcept {
+        if (ptr_) {
+            clear_memory(&ptr_, use_gpu_);
+        }
+        size_ = 0;
+    }
+
+    // Relinquishes ownership; the caller becomes responsible for freeing the
+    // returned pointer with the matching allocator (free / cudaFree).
+    [[nodiscard]] HOST T* release() noexcept {
+        T* released = ptr_;
+        ptr_ = nullptr;
+        size_ = 0;
+        return released;
+    }
+
+    [[nodiscard]] HOST T* data() const noexcept { return ptr_; }
+    [[nodiscard]] HOST T* get() const noexcept { return ptr_; }
+    [[nodiscard]] HOST size_t size() const noexcept { return size_; }
+    [[nodiscard]] HOST bool use_gpu() const noexcept { return use_gpu_; }
+    [[nodiscard]] HOST explicit operator bool() const noexcept { return ptr_ != nullptr; }
+
+private:
+    T* ptr_ = nullptr;
+    size_t size_ = 0;
+    bool use_gpu_ = false;
+};
+
+#endif // CUDA_BUFFER_CUH

--- a/temporal_random_walk/src/data/structs.cuh
+++ b/temporal_random_walk/src/data/structs.cuh
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <cstring>
 #include <utility>
+#include "../common/cuda_buffer.cuh"
 #include "../common/memory.cuh"
 #include "../common/macros.cuh"
 #include "walk_set/walk_set.cuh"
@@ -109,11 +110,11 @@ struct MemoryView {
 
 struct WalksWithEdgeFeatures {
     WalkSet walk_set;
-    float* walk_edge_features;
+    CudaBuffer<float> walk_edge_features;
     int feature_dim;
 
     HOST WalksWithEdgeFeatures(WalkSet walk_set, const int feature_dim)
-        : walk_set(std::move(walk_set)), walk_edge_features(nullptr), feature_dim(feature_dim) {
+        : walk_set(std::move(walk_set)), feature_dim(feature_dim) {
         if (feature_dim <= 0) {
             return;
         }
@@ -123,13 +124,14 @@ struct WalksWithEdgeFeatures {
             return;
         }
 
-        allocate_memory(&walk_edge_features, walk_edge_features_size, false);
-        std::memset(walk_edge_features, 0, walk_edge_features_size * sizeof(float));
+        walk_edge_features = CudaBuffer<float>(walk_edge_features_size, false);
+        std::memset(walk_edge_features.data(), 0, walk_edge_features_size * sizeof(float));
     }
 
-    HOST ~WalksWithEdgeFeatures() {
-        clear_memory(&walk_edge_features, false);
-    }
+    WalksWithEdgeFeatures(const WalksWithEdgeFeatures&) = delete;
+    WalksWithEdgeFeatures& operator=(const WalksWithEdgeFeatures&) = delete;
+    HOST WalksWithEdgeFeatures(WalksWithEdgeFeatures&&) noexcept = default;
+    HOST WalksWithEdgeFeatures& operator=(WalksWithEdgeFeatures&&) noexcept = default;
 
     HOST size_t size() const {
         return walk_set.size();
@@ -148,6 +150,11 @@ struct WalksWithEdgeFeatures {
             return;
         }
 
+        float* const dst_base = walk_edge_features.data();
+        if (dst_base == nullptr) {
+            return;
+        }
+
         const auto feature_dim_size_t = static_cast<size_t>(feature_dim);
         const size_t walk_edges_count = walk_set.edge_ids_size;
 
@@ -158,7 +165,7 @@ struct WalksWithEdgeFeatures {
             }
 
             const auto edge_id = static_cast<size_t>(walk_set.edge_ids[i]);
-            float* dst = walk_edge_features + (i * feature_dim_size_t);
+            float* dst = dst_base + (i * feature_dim_size_t);
             const float* src = edge_features + (edge_id * feature_dim_size_t);
             std::memcpy(dst, src, feature_dim_size_t * sizeof(float));
         }

--- a/temporal_random_walk/src/proxies/NodeFeatures.cu
+++ b/temporal_random_walk/src/proxies/NodeFeatures.cu
@@ -1,12 +1,6 @@
 #include "NodeFeatures.cuh"
 
-NodeFeatures::NodeFeatures() {
-    node_features = new NodeFeaturesStore();
-}
-
-NodeFeatures::~NodeFeatures() {
-    delete node_features;
-}
+NodeFeatures::NodeFeatures() : node_features(std::make_unique<NodeFeaturesStore>()) {}
 
 void NodeFeatures::set_node_features(
     const int max_node_id,
@@ -15,7 +9,7 @@ void NodeFeatures::set_node_features(
     const float* node_features,
     const size_t feature_dim) const {
     node_features::set_node_features(
-        this->node_features,
+        this->node_features.get(),
         max_node_id,
         node_ids,
         num_nodes,
@@ -33,5 +27,5 @@ int NodeFeatures::max_node_id() const {
 
 
 NodeFeaturesStore* NodeFeatures::get_node_features() const {
-    return node_features;
+    return node_features.get();
 }

--- a/temporal_random_walk/src/proxies/NodeFeatures.cuh
+++ b/temporal_random_walk/src/proxies/NodeFeatures.cuh
@@ -1,14 +1,15 @@
 #ifndef NODE_FEATURES_H
 #define NODE_FEATURES_H
 
+#include <memory>
+
 #include "../stores/node_features.cuh"
 
 class NodeFeatures {
 public:
-    NodeFeaturesStore* node_features;
-    explicit NodeFeatures();
+    std::unique_ptr<NodeFeaturesStore> node_features;
 
-    ~NodeFeatures();
+    NodeFeatures();
 
     void set_node_features(
         int max_node_id,

--- a/temporal_random_walk/src/proxies/TemporalRandomWalk.cu
+++ b/temporal_random_walk/src/proxies/TemporalRandomWalk.cu
@@ -29,9 +29,8 @@ TemporalRandomWalk::TemporalRandomWalk(
 
         const int walk_padding_value,
         const uint64_t global_seed,
-        const bool shuffle_walk_order): use_gpu(use_gpu) {
-
-    temporal_random_walk = new TemporalRandomWalkStore(
+        const bool shuffle_walk_order): use_gpu(use_gpu),
+    temporal_random_walk(std::make_unique<TemporalRandomWalkStore>(
         is_directed,
         use_gpu,
 
@@ -45,14 +44,8 @@ TemporalRandomWalk::TemporalRandomWalk(
 
         walk_padding_value,
         global_seed,
-        shuffle_walk_order);
-    node_features = new NodeFeatures();
-}
-
-TemporalRandomWalk::~TemporalRandomWalk() {
-    delete node_features;
-    delete temporal_random_walk;
-}
+        shuffle_walk_order)),
+    node_features(std::make_unique<NodeFeatures>()) {}
 
 void TemporalRandomWalk::add_multiple_edges(
     const int* sources,
@@ -62,7 +55,7 @@ void TemporalRandomWalk::add_multiple_edges(
     const float* edge_features,
     const size_t feature_dim) const {
     temporal_random_walk::add_multiple_edges(
-        temporal_random_walk,
+        temporal_random_walk.get(),
         sources,
         targets,
         timestamps,
@@ -121,7 +114,7 @@ WalksWithEdgeFeatures TemporalRandomWalk::get_random_walks_and_times_for_all_nod
     #ifdef HAS_CUDA
     if (use_gpu) {
         walk_set = temporal_random_walk::get_random_walks_and_times_for_all_nodes_cuda(
-            temporal_random_walk,
+            temporal_random_walk.get(),
             max_walk_len,
             walk_bias,
             num_walks_per_node,
@@ -133,7 +126,7 @@ WalksWithEdgeFeatures TemporalRandomWalk::get_random_walks_and_times_for_all_nod
     #endif
     {
         walk_set = temporal_random_walk::get_random_walks_and_times_for_all_nodes_std(
-            temporal_random_walk,
+            temporal_random_walk.get(),
             max_walk_len,
             walk_bias,
             num_walks_per_node,
@@ -161,7 +154,7 @@ WalksWithEdgeFeatures TemporalRandomWalk::get_random_walks_and_times_for_last_ba
     #ifdef HAS_CUDA
     if (use_gpu) {
         walk_set = temporal_random_walk::get_random_walks_and_times_for_last_batch_cuda(
-            temporal_random_walk,
+            temporal_random_walk.get(),
             max_walk_len,
             walk_bias,
             num_walks_per_node,
@@ -173,7 +166,7 @@ WalksWithEdgeFeatures TemporalRandomWalk::get_random_walks_and_times_for_last_ba
     #endif
     {
         walk_set = temporal_random_walk::get_random_walks_and_times_for_last_batch_std(
-            temporal_random_walk,
+            temporal_random_walk.get(),
             max_walk_len,
             walk_bias,
             num_walks_per_node,
@@ -202,7 +195,7 @@ WalksWithEdgeFeatures TemporalRandomWalk::get_random_walks_and_times(
     #ifdef HAS_CUDA
     if (use_gpu) {
         walk_set = temporal_random_walk::get_random_walks_and_times_cuda(
-            temporal_random_walk,
+            temporal_random_walk.get(),
             max_walk_len,
             walk_bias,
             num_walks_total,
@@ -214,7 +207,7 @@ WalksWithEdgeFeatures TemporalRandomWalk::get_random_walks_and_times(
     #endif
     {
         walk_set = temporal_random_walk::get_random_walks_and_times_std(
-            temporal_random_walk,
+            temporal_random_walk.get(),
             max_walk_len,
             walk_bias,
             num_walks_total,
@@ -231,7 +224,7 @@ WalksWithEdgeFeatures TemporalRandomWalk::get_random_walks_and_times(
 }
 
 size_t TemporalRandomWalk::get_node_count() const {
-    return temporal_random_walk::get_node_count(temporal_random_walk);
+    return temporal_random_walk::get_node_count(temporal_random_walk.get());
 }
 
 size_t TemporalRandomWalk::get_edge_count() const {
@@ -241,7 +234,7 @@ size_t TemporalRandomWalk::get_edge_count() const {
         size_t* d_result;
         CUDA_CHECK_AND_CLEAR(cudaMalloc(&d_result, sizeof(size_t)));
 
-        TemporalRandomWalkStore* d_temporal_random_walk = temporal_random_walk::to_device_ptr(temporal_random_walk);
+        TemporalRandomWalkStore* d_temporal_random_walk = temporal_random_walk::to_device_ptr(temporal_random_walk.get());
         get_edge_count_kernel<<<1, 1>>>(d_result, d_temporal_random_walk);
         CUDA_KERNEL_CHECK("After get_edge_count_kernel execution");
 
@@ -257,12 +250,12 @@ size_t TemporalRandomWalk::get_edge_count() const {
     #endif
     {
         // Direct call for CPU implementation
-        return temporal_random_walk::get_edge_count(temporal_random_walk);
+        return temporal_random_walk::get_edge_count(temporal_random_walk.get());
     }
 }
 
 std::vector<int> TemporalRandomWalk::get_node_ids() const {
-    const DataBlock<int> node_ids = temporal_random_walk::get_node_ids(temporal_random_walk);
+    const DataBlock<int> node_ids = temporal_random_walk::get_node_ids(temporal_random_walk.get());
     std::vector<int> result;
 
     #ifdef HAS_CUDA
@@ -289,7 +282,7 @@ std::vector<int> TemporalRandomWalk::get_node_ids() const {
 std::vector<std::tuple<int, int, int64_t>> TemporalRandomWalk::get_edges() const {
     // temporal_random_walk::get_edges ultimately delegates to edge_data::get_edges,
     // which always returns CPU-resident edges.
-    const DataBlock<Edge> edges = temporal_random_walk::get_edges(temporal_random_walk);
+    const DataBlock<Edge> edges = temporal_random_walk::get_edges(temporal_random_walk.get());
     std::vector<std::tuple<int, int, int64_t>> result;
     result.reserve(edges.size);
 
@@ -304,13 +297,13 @@ std::vector<std::tuple<int, int, int64_t>> TemporalRandomWalk::get_edges() const
 }
 
 bool TemporalRandomWalk::get_is_directed() const {
-    return temporal_random_walk::get_is_directed(temporal_random_walk);
+    return temporal_random_walk::get_is_directed(temporal_random_walk.get());
 }
 
 void TemporalRandomWalk::clear() const {
-    temporal_random_walk::clear(temporal_random_walk);
+    temporal_random_walk::clear(temporal_random_walk.get());
 }
 
 size_t TemporalRandomWalk::get_memory_used() const {
-    return temporal_random_walk::get_memory_used(temporal_random_walk);
+    return temporal_random_walk::get_memory_used(temporal_random_walk.get());
 }

--- a/temporal_random_walk/src/proxies/TemporalRandomWalk.cuh
+++ b/temporal_random_walk/src/proxies/TemporalRandomWalk.cuh
@@ -1,6 +1,7 @@
 #ifndef TEMPORAL_RANDOM_WALK_H
 #define TEMPORAL_RANDOM_WALK_H
 
+#include <memory>
 #include <vector>
 #include <thread>
 #include "../core/temporal_random_walk.cuh"
@@ -18,8 +19,8 @@ __global__ void get_edge_count_kernel(size_t* result, const TemporalRandomWalkSt
 
 class TemporalRandomWalk {
     bool use_gpu;
-    TemporalRandomWalkStore* temporal_random_walk;
-    NodeFeatures* node_features;
+    std::unique_ptr<TemporalRandomWalkStore> temporal_random_walk;
+    std::unique_ptr<NodeFeatures> node_features;
 
 public:
     explicit TemporalRandomWalk(
@@ -37,8 +38,6 @@ public:
         int walk_padding_value=EMPTY_NODE_VALUE,
         uint64_t global_seed=EMPTY_GLOBAL_SEED,
         bool shuffle_walk_order=DEFAULT_SHUFFLE_WALK_ORDER);
-
-    ~TemporalRandomWalk();
 
     void add_multiple_edges(
         const int* sources,

--- a/temporal_random_walk/src/stores/node_features.cu
+++ b/temporal_random_walk/src/stores/node_features.cu
@@ -2,7 +2,10 @@
 
 #include <cstring>
 #include <stdexcept>
+#include <utility>
 #include <omp.h>
+
+#include "../common/memory.cuh"
 
 void node_features::ensure_size(NodeFeaturesStore* node_features_store, const int max_node_id) {
     if (max_node_id <= node_features_store->max_node_id) {
@@ -14,20 +17,23 @@ void node_features::ensure_size(NodeFeaturesStore* node_features_store, const in
         return;
     }
 
-    const size_t old_values = node_features_store->node_features_size;
+    const size_t old_values = node_features_store->node_features.size();
     const size_t new_values = static_cast<size_t>(max_node_id + 1) * node_features_store->node_feature_dim;
 
-    resize_memory(
-        &node_features_store->node_features,
-        old_values,
-        new_values,
-        false);
-
+    CudaBuffer<float> new_buffer(new_values, node_features_store->use_gpu);
+    if (old_values > 0) {
+        copy_memory(
+            new_buffer.data(),
+            node_features_store->node_features.data(),
+            old_values,
+            node_features_store->use_gpu,
+            node_features_store->use_gpu);
+    }
     if (new_values > old_values) {
-        std::memset(node_features_store->node_features + old_values, 0, (new_values - old_values) * sizeof(float));
+        std::memset(new_buffer.data() + old_values, 0, (new_values - old_values) * sizeof(float));
     }
 
-    node_features_store->node_features_size = new_values;
+    node_features_store->node_features = std::move(new_buffer);
     node_features_store->max_node_id = max_node_id;
 }
 
@@ -55,10 +61,12 @@ void node_features::set_node_features(
     store->node_feature_dim = feature_dim;
     ensure_size(store, max_node_id);
 
+    float* const dst_base = store->node_features.data();
+
     #pragma omp parallel for schedule(static)
     for (size_t i = 0; i < num_nodes; ++i) {
         const int node_id = node_ids[i];
-        float* dst = store->node_features + (static_cast<size_t>(node_id) * feature_dim);
+        float* dst = dst_base + (static_cast<size_t>(node_id) * feature_dim);
         const float* src = node_features + (i * feature_dim);
         std::memcpy(dst, src, feature_dim * sizeof(float));
     }

--- a/temporal_random_walk/src/stores/node_features.cuh
+++ b/temporal_random_walk/src/stores/node_features.cuh
@@ -2,38 +2,28 @@
 #define NODE_FEATURES_STORE_H
 
 #include <cstddef>
+#include "../common/cuda_buffer.cuh"
 #include "../common/macros.cuh"
-#include "../common/memory.cuh"
 
 struct NodeFeaturesStore {
     bool use_gpu = false;
-    bool owns_data = true;
 
     int max_node_id = -1;
     size_t node_feature_dim = 0;
 
-    float* node_features = nullptr;
-    size_t node_features_size = 0;
+    CudaBuffer<float> node_features;
 
     NodeFeaturesStore() = default;
-
-    ~NodeFeaturesStore() {
-        if (owns_data) {
-            clear_memory(&node_features, false);
-        } else {
-            node_features = nullptr;
-        }
-    }
 };
 
 namespace node_features {
 
     HOST inline size_t size(const NodeFeaturesStore* node_features_store) {
-        return node_features_store->node_features_size;
+        return node_features_store->node_features.size();
     }
 
     HOST inline bool empty(const NodeFeaturesStore* node_features_store) {
-        return node_features_store->node_features_size == 0;
+        return node_features_store->node_features.size() == 0;
     }
 
     HOST void ensure_size(NodeFeaturesStore* node_features_store, int max_node_id);

--- a/temporal_random_walk/test/test_node_features.cpp
+++ b/temporal_random_walk/test/test_node_features.cpp
@@ -16,18 +16,18 @@ TEST(NodeFeaturesTest, SetNodeFeaturesPreservesOldDataOnGrow) {
     nf.set_node_features(edge_data.max_node_id, first_ids.data(), first_ids.size(), first_features.data(), 2);
 
     const auto* store = nf.get_node_features();
-    EXPECT_FLOAT_EQ(store->node_features[1 * 2], 1.0f);
-    EXPECT_FLOAT_EQ(store->node_features[1 * 2 + 1], 2.0f);
+    EXPECT_FLOAT_EQ(store->node_features.data()[1 * 2], 1.0f);
+    EXPECT_FLOAT_EQ(store->node_features.data()[1 * 2 + 1], 2.0f);
 
     edge_data.max_node_id = 5;
     std::vector<int> second_ids{5};
     std::vector<float> second_features{9.0f, 10.0f};
     nf.set_node_features(edge_data.max_node_id, second_ids.data(), second_ids.size(), second_features.data(), 2);
 
-    EXPECT_FLOAT_EQ(store->node_features[1 * 2], 1.0f);
-    EXPECT_FLOAT_EQ(store->node_features[1 * 2 + 1], 2.0f);
-    EXPECT_FLOAT_EQ(store->node_features[5 * 2], 9.0f);
-    EXPECT_FLOAT_EQ(store->node_features[5 * 2 + 1], 10.0f);
+    EXPECT_FLOAT_EQ(store->node_features.data()[1 * 2], 1.0f);
+    EXPECT_FLOAT_EQ(store->node_features.data()[1 * 2 + 1], 2.0f);
+    EXPECT_FLOAT_EQ(store->node_features.data()[5 * 2], 9.0f);
+    EXPECT_FLOAT_EQ(store->node_features.data()[5 * 2 + 1], 10.0f);
 
     EXPECT_EQ(nf.max_node_id(), 5);
     EXPECT_EQ(nf.node_feature_dim(), 2);
@@ -45,7 +45,7 @@ TEST(NodeFeaturesTest, SetNodeFeaturesWithPointers) {
     nf.set_node_features(edge_data.max_node_id, node_ids.data(), node_ids.size(), node_features.data(), 3);
 
     const auto* store = nf.get_node_features();
-    EXPECT_FLOAT_EQ(store->node_features[2], 9.0f);
-    EXPECT_FLOAT_EQ(store->node_features[2 * 3], 1.0f);
+    EXPECT_FLOAT_EQ(store->node_features.data()[2], 9.0f);
+    EXPECT_FLOAT_EQ(store->node_features.data()[2 * 3], 1.0f);
     EXPECT_EQ(nf.node_feature_dim(), 3);
 }

--- a/temporal_random_walk/test/test_temporal_random_walk_edge_features.cpp
+++ b/temporal_random_walk/test/test_temporal_random_walk_edge_features.cpp
@@ -96,7 +96,7 @@ TYPED_TEST(TemporalWalkTestWithEdgeFeatures, ReturnsFeatureMetadata) {
         MAX_WALK_LEN, &linear_picker_type, 20);
 
     EXPECT_EQ(walks.feature_dim, static_cast<int>(this->feature_dim));
-    EXPECT_NE(walks.walk_edge_features, nullptr);
+    EXPECT_NE(walks.walk_edge_features.data(), nullptr);
 }
 
 TYPED_TEST(TemporalWalkTestWithEdgeFeatures, PopulatesWalkEdgeFeaturesForTraversedEdges) {
@@ -128,7 +128,7 @@ TYPED_TEST(TemporalWalkTestWithEdgeFeatures, PopulatesWalkEdgeFeaturesForTravers
             ASSERT_NE(it, this->expected_feature_by_edge.end())
                 << "Traversed edge missing in expected-feature map";
 
-            const float* sampled = walks.walk_edge_features + (edge_slot * this->feature_dim);
+            const float* sampled = walks.walk_edge_features.data() + (edge_slot * this->feature_dim);
             EXPECT_FLOAT_EQ(sampled[0], it->second[0]);
             EXPECT_FLOAT_EQ(sampled[1], it->second[1]);
             EXPECT_FLOAT_EQ(sampled[2], it->second[2]);
@@ -149,7 +149,7 @@ TYPED_TEST(TemporalWalkTestWithEdgeFeatures, KeepsUnusedEdgeSlotsAsEmptyAndZeroe
             const size_t edge_slot = this->edge_slot_index(walks, walk_idx, step_idx);
             EXPECT_EQ(walk_set.edge_ids[edge_slot], EMPTY_EDGE_ID);
 
-            const float* sampled = walks.walk_edge_features + (edge_slot * this->feature_dim);
+            const float* sampled = walks.walk_edge_features.data() + (edge_slot * this->feature_dim);
             EXPECT_FLOAT_EQ(sampled[0], 0.0f);
             EXPECT_FLOAT_EQ(sampled[1], 0.0f);
             EXPECT_FLOAT_EQ(sampled[2], 0.0f);

--- a/temporal_random_walk/test_run/test_utils.h
+++ b/temporal_random_walk/test_run/test_utils.h
@@ -46,14 +46,15 @@ inline void print_temporal_random_walks_with_times_and_weights(
         }
 
         std::cout << "Weights: [";
-        if (feature_dim > 0 && walks_with_edge_features.walk_edge_features != nullptr) {
+        const float* const walk_edge_features_data = walks_with_edge_features.walk_edge_features.data();
+        if (feature_dim > 0 && walk_edge_features_data != nullptr) {
             for (size_t hop = 1; hop < walk_len; ++hop) {
                 const size_t edge_offset = edge_base + (hop - 1);
                 std::cout << "[";
                 for (int feat_idx = 0; feat_idx < feature_dim; ++feat_idx) {
                     const size_t feature_offset = edge_offset * static_cast<size_t>(feature_dim) +
                                                   static_cast<size_t>(feat_idx);
-                    std::cout << walks_with_edge_features.walk_edge_features[feature_offset];
+                    std::cout << walk_edge_features_data[feature_offset];
                     if (feat_idx + 1 < feature_dim) {
                         std::cout << ", ";
                     }


### PR DESCRIPTION
## Summary
Refactor memory management to use a new `CudaBuffer` RAII wrapper class instead of raw pointers, eliminating manual allocation/deallocation and ownership tracking flags.

## Key Changes

- **New `CudaBuffer<T>` class** (`cuda_buffer.cuh`): Move-only RAII wrapper that automatically manages host or device memory allocation and deallocation. Replaces patterns of raw `T*` pointers paired with manual `allocate_memory`/`clear_memory` calls and `owns_*` flags.

- **`NodeFeaturesStore` refactoring**: 
  - Replaced `float* node_features` and `size_t node_features_size` with `CudaBuffer<float> node_features`
  - Removed `owns_data` flag (no longer needed with RAII)
  - Removed manual destructor
  - Updated `ensure_size()` to use `CudaBuffer` and `copy_memory()` for resizing

- **`WalksWithEdgeFeatures` refactoring**:
  - Replaced `float* walk_edge_features` with `CudaBuffer<float> walk_edge_features`
  - Removed manual destructor
  - Added deleted copy constructors/assignment operators
  - Added defaulted move constructors/assignment operators
  - Updated Python binding code to use `.release()` for ownership transfer to pybind11

- **Python binding updates** (`_temporal_random_walk.cu`):
  - Changed null checks from `!= nullptr` to boolean conversion (`operator bool()`)
  - Used `.data()` accessor instead of raw pointer access
  - Used `.release()` to transfer ownership to pybind11 capsules, eliminating manual null assignment

- **Test updates**: Updated all test code to use `.data()` accessor for accessing buffer contents

## Implementation Details

- `CudaBuffer` supports both host (CPU) and device (GPU) memory via the `use_gpu` flag
- Move semantics properly transfer ownership between objects
- The `release()` method allows controlled ownership transfer (e.g., to Python objects)
- All existing memory allocation/deallocation logic is preserved through the underlying `allocate_memory` and `clear_memory` functions

https://claude.ai/code/session_01KwdfSz44czhhkpbWKaoGdJ