### PR TITLE
Refactor CUDA error handling: throw exceptions instead of exit

### DIFF
--- a/temporal_random_walk/src/common/error_handlers.cuh
+++ b/temporal_random_walk/src/common/error_handlers.cuh
@@ -5,80 +5,129 @@
 
 #include <cuda_runtime.h>
 #include <iostream>
+#include <sstream>
+#include <stdexcept>
 #include <string>
 
 /**
- * Macro that checks for CUDA errors and clears the error state, then exits.
- * This prevents errors from "sticking" around and causing false positives later
+ * Checks a synchronous CUDA runtime call. Throws std::runtime_error on failure.
+ * Also clears any sticky prior error before the call so a failure here cannot
+ * be confused with a failure from earlier code.
  */
 #define CUDA_CHECK_AND_CLEAR(call) do { \
-    /* Clear any prior errors */ \
-    cudaGetLastError(); \
-    \
-    /* Make the call */ \
-    cudaError_t err = call; \
-    \
-    /* Check for errors from this call */ \
-    if (err != cudaSuccess) { \
-        std::cerr << "CUDA error in " << __FILE__ << ":" << __LINE__ << "\n"; \
-        std::cerr << "  Code: " << err << " (" << cudaGetErrorString(err) << ")\n"; \
-        std::cerr << "  Call: " << #call << "\n"; \
-        std::exit(EXIT_FAILURE); \
+    cudaGetLastError(); /* clear any prior error */ \
+    cudaError_t _err = (call); \
+    if (_err != cudaSuccess) { \
+        std::ostringstream _oss; \
+        _oss << "CUDA error in " << __FILE__ << ":" << __LINE__ \
+             << " code=" << _err << " (" << cudaGetErrorString(_err) << ") " \
+             << "call=" << #call; \
+        throw std::runtime_error(_oss.str()); \
     } \
 } while(0)
 
 /**
- * Macro to check for errors after asynchronous operations like kernel launches
- * Clears error state before and after checking
+ * Asynchronous kernel-launch check.
+ *
+ * Only calls cudaGetLastError(), which catches launch-configuration errors
+ * (bad grid/block, too much shared memory, invalid args, etc.) without
+ * stalling the device. This is the production check: it lets kernels queue up
+ * on the stream without a synchronization barrier between them.
+ *
+ * Asynchronous errors (out-of-bounds accesses, kernel aborts) will not be
+ * caught here; they surface at the next synchronizing call
+ * (cudaMemcpy, cudaStreamSynchronize, etc.) or via CUDA_KERNEL_CHECK_SYNC.
  */
-#define CUDA_KERNEL_CHECK(msg) do { \
-    cudaError_t err = cudaGetLastError(); \
-    if (err != cudaSuccess) { \
-        std::cerr << "CUDA error in " << __FILE__ << ":" << __LINE__ << "\n"; \
-        std::cerr << "  Code: " << err << " (" << cudaGetErrorString(err) << ")\n"; \
-        std::cerr << "  Message: " << msg << "\n"; \
-        std::exit(EXIT_FAILURE); \
-    } \
-    /* Synchronize to catch asynchronous errors */ \
-    err = cudaDeviceSynchronize(); \
-    if (err != cudaSuccess) { \
-        std::cerr << "CUDA synchronization error in " << __FILE__ << ":" << __LINE__ << "\n"; \
-        std::cerr << "  Code: " << err << " (" << cudaGetErrorString(err) << ")\n"; \
-        std::cerr << "  Message: " << msg << " (during synchronization)\n"; \
-        std::exit(EXIT_FAILURE); \
+#define CUDA_KERNEL_CHECK_ASYNC(msg) do { \
+    cudaError_t _err = cudaGetLastError(); \
+    if (_err != cudaSuccess) { \
+        std::ostringstream _oss; \
+        _oss << "CUDA launch error in " << __FILE__ << ":" << __LINE__ \
+             << " code=" << _err << " (" << cudaGetErrorString(_err) << ") " \
+             << "msg=" << (msg); \
+        throw std::runtime_error(_oss.str()); \
     } \
 } while(0)
 
 /**
- * Macro to check for errors in CURAND
- * Clears error state before and after checking
+ * Synchronous kernel check. Checks the launch error AND synchronizes the
+ * device to surface any asynchronous kernel errors.
+ *
+ * Use this sparingly and deliberately — never in the hot path of a streaming
+ * workload. Appropriate places: right before copying results to host, at the
+ * end of a self-contained benchmark region, or in tests.
+ */
+#define CUDA_KERNEL_CHECK_SYNC(msg) do { \
+    cudaError_t _err = cudaGetLastError(); \
+    if (_err != cudaSuccess) { \
+        std::ostringstream _oss; \
+        _oss << "CUDA launch error in " << __FILE__ << ":" << __LINE__ \
+             << " code=" << _err << " (" << cudaGetErrorString(_err) << ") " \
+             << "msg=" << (msg); \
+        throw std::runtime_error(_oss.str()); \
+    } \
+    _err = cudaDeviceSynchronize(); \
+    if (_err != cudaSuccess) { \
+        std::ostringstream _oss; \
+        _oss << "CUDA sync error in " << __FILE__ << ":" << __LINE__ \
+             << " code=" << _err << " (" << cudaGetErrorString(_err) << ") " \
+             << "msg=" << (msg) << " (during synchronization)"; \
+        throw std::runtime_error(_oss.str()); \
+    } \
+} while(0)
+
+/**
+ * Backward-compatible alias kept so the 84 existing call sites do not need to
+ * change. In debug builds this preserves the old synchronous behavior so that
+ * async errors surface at the offending kernel. In release builds it becomes
+ * the async-only check, which is what production should have been doing.
+ *
+ * New code should prefer CUDA_KERNEL_CHECK_ASYNC explicitly and only reach
+ * for CUDA_KERNEL_CHECK_SYNC when a sync point is genuinely intended.
+ */
+#ifdef NDEBUG
+    #define CUDA_KERNEL_CHECK(msg) CUDA_KERNEL_CHECK_ASYNC(msg)
+#else
+    #define CUDA_KERNEL_CHECK(msg) CUDA_KERNEL_CHECK_SYNC(msg)
+#endif
+
+/**
+ * cuRAND error check. Throws on failure.
  */
 #define CHECK_CURAND(call) do { \
-    curandStatus_t status = call; \
-    if (status != CURAND_STATUS_SUCCESS) { \
-        std::cerr << "cuRAND error" << std::endl; exit(EXIT_FAILURE); \
+    curandStatus_t _status = (call); \
+    if (_status != CURAND_STATUS_SUCCESS) { \
+        std::ostringstream _oss; \
+        _oss << "cuRAND error in " << __FILE__ << ":" << __LINE__ \
+             << " status=" << static_cast<int>(_status) << " " \
+             << "call=" << #call; \
+        throw std::runtime_error(_oss.str()); \
     } \
 } while(0)
 
 /**
- * Macro to check for errors in CUB
+ * CUB error check. Throws on failure.
  */
 #define CUB_CHECK(call) do { \
-    cudaError_t err = (call); \
-    if (err != cudaSuccess) { \
-        fprintf(stderr, "CUB error at %s:%d: %s\n", __FILE__, __LINE__, cudaGetErrorString(err)); \
-        exit(EXIT_FAILURE); \
+    cudaError_t _err = (call); \
+    if (_err != cudaSuccess) { \
+        std::ostringstream _oss; \
+        _oss << "CUB error in " << __FILE__ << ":" << __LINE__ \
+             << " code=" << _err << " (" << cudaGetErrorString(_err) << ") " \
+             << "call=" << #call; \
+        throw std::runtime_error(_oss.str()); \
     } \
-} while (0)
+} while(0)
 
 /**
- * Function to reset CUDA error state
- * Call this if you want to explicitly clear error state without checking
+ * Explicitly clear the sticky CUDA error state. Use when you want to discard
+ * a known-prior error without reacting to it (e.g., the intentional
+ * cudaPointerGetAttributes probe in clear_memory).
  */
 inline void clearCudaErrorState() {
-    cudaGetLastError(); // This clears the error state
+    cudaGetLastError();
 }
 
-#endif
+#endif // HAS_CUDA
 
 #endif // CUDA_ERROR_HANDLERS

--- a/temporal_random_walk/src/common/memory.cuh
+++ b/temporal_random_walk/src/common/memory.cuh
@@ -98,7 +98,7 @@ HOST void fill_memory(T* memory, size_t size, T value, bool use_gpu) {
         int blocksPerGrid = (size + threadsPerBlock - 1) / threadsPerBlock;
 
         fill_kernel<<<blocksPerGrid, threadsPerBlock>>>(memory, size, d_value);
-        CUDA_KERNEL_CHECK("After fill_kernel execution");
+        CUDA_KERNEL_CHECK_SYNC("After fill_kernel execution");
 
         CUDA_CHECK_AND_CLEAR(cudaFree(d_value));
     }

--- a/temporal_random_walk/src/stores/node_edge_index.cu
+++ b/temporal_random_walk/src/stores/node_edge_index.cu
@@ -836,18 +836,35 @@ HOST void node_edge_index::compute_node_group_offsets_cuda(
     int *src_ptr = edge_data->sources;
     int *tgt_ptr = edge_data->targets;
 
-    // Count edges per node using atomics
+    // Count edges per node using 64-bit atomics on the full size_t slot.
+    // Rationale: outbound_offsets_ptr / inbound_offsets_ptr are size_t (64-bit)
+    // arrays. The 32-bit reinterpret that used to live here silently overflowed
+    // for any node reaching 2^32 incident edges and was endian-dependent. CUDA
+    // provides atomicAdd on unsigned long long natively on all compute
+    // capabilities >= 3.5 (we target 75/80/86/89/90).
+    //
+    // sizeof(size_t) == sizeof(unsigned long long) on every CUDA-supported
+    // platform (64-bit host, little-endian). The static_assert below encodes
+    // that assumption so a future port on a platform where it fails to hold
+    // breaks at compile time rather than silently.
+    static_assert(sizeof(size_t) == sizeof(unsigned long long),
+                  "size_t must be 64-bit for compute_node_group_offsets_cuda's "
+                  "atomicAdd; revisit the cast if this platform differs.");
+
     auto counter_device_lambda = [
                 outbound_offsets_ptr, inbound_offsets_ptr,
                 src_ptr, tgt_ptr, is_directed] DEVICE (const size_t i) {
         const int src_idx = src_ptr[i];
         const int tgt_idx = tgt_ptr[i];
 
-        atomicAdd(reinterpret_cast<unsigned int *>(&outbound_offsets_ptr[src_idx + 1]), 1);
+        atomicAdd(reinterpret_cast<unsigned long long *>(&outbound_offsets_ptr[src_idx + 1]),
+                  static_cast<unsigned long long>(1));
         if (is_directed) {
-            atomicAdd(reinterpret_cast<unsigned int *>(&inbound_offsets_ptr[tgt_idx + 1]), 1);
+            atomicAdd(reinterpret_cast<unsigned long long *>(&inbound_offsets_ptr[tgt_idx + 1]),
+                      static_cast<unsigned long long>(1));
         } else {
-            atomicAdd(reinterpret_cast<unsigned int *>(&outbound_offsets_ptr[tgt_idx + 1]), 1);
+            atomicAdd(reinterpret_cast<unsigned long long *>(&outbound_offsets_ptr[tgt_idx + 1]),
+                      static_cast<unsigned long long>(1));
         }
     };
 


### PR DESCRIPTION
## Summary
Refactored all CUDA error handling macros to throw `std::runtime_error` exceptions instead of calling `std::exit()`, improving error handling robustness and testability. Also fixed a critical 32-bit overflow bug in atomic operations and clarified the distinction between synchronous and asynchronous kernel error checking.

## Key Changes

- **Exception-based error handling**: All error macros (`CUDA_CHECK_AND_CLEAR`, `CUDA_KERNEL_CHECK`, `CHECK_CURAND`, `CUB_CHECK`) now throw `std::runtime_error` with detailed context instead of printing to stderr and exiting. This allows callers to catch and handle errors gracefully.

- **Improved error messages**: Error messages now use `std::ostringstream` for consistent formatting and include file, line number, error code, error string, and the failing call/message in a structured format.

- **Split kernel error checking**: 
  - `CUDA_KERNEL_CHECK_ASYNC`: Checks launch errors only via `cudaGetLastError()` without synchronization (suitable for hot paths)
  - `CUDA_KERNEL_CHECK_SYNC`: Checks launch errors AND synchronizes device to catch asynchronous kernel errors (use deliberately, not in streaming workloads)
  - `CUDA_KERNEL_CHECK`: Backward-compatible macro that aliases to `CUDA_KERNEL_CHECK_SYNC` in debug builds and `CUDA_KERNEL_CHECK_ASYNC` in release builds

- **Fixed atomic operation overflow bug**: Changed 32-bit `atomicAdd` calls to 64-bit `unsigned long long` in `compute_node_group_offsets_cuda()`. The previous 32-bit reinterpret cast silently overflowed for nodes with ≥2³² incident edges and was endian-dependent. Added a `static_assert` to ensure `size_t` is 64-bit on the target platform.

- **Updated includes**: Added `<sstream>` and `<stdexcept>` headers to support exception-based error handling.

- **Updated call sites**: Changed `fill_memory()` to use `CUDA_KERNEL_CHECK_SYNC` explicitly to document the intentional synchronization point.

## Implementation Details

- All macro variables are prefixed with `_` to avoid shadowing user code
- Error messages follow a consistent pattern: `"<error_type> in <file>:<line> code=<code> (<string>) <context>"`
- The backward-compatible `CUDA_KERNEL_CHECK` macro uses preprocessor conditionals to preserve debug-build behavior while allowing release builds to use the more efficient async-only check
- The atomic operation fix includes detailed comments explaining the rationale and platform assumptions

https://claude.ai/code/session_01SRpfpCC5yRSRQmMo87BK4t