### PR TITLE
fix(cuda): plug two correctness bugs in the GPU walk/trim paths

### DIFF
--- a/temporal_random_walk/src/core/temporal_random_walk.cu
+++ b/temporal_random_walk/src/core/temporal_random_walk.cu
@@ -650,6 +650,13 @@ temporal_random_walk::get_random_walks_and_times_for_all_nodes_cuda(
 
     const TemporalGraphView view = make_temporal_graph_view(trw->data());
 
+    // Drain stream-0 work issued by the prep phase (repeat_elements,
+    // shuffle_vector_device, WalkSetDevice::fill) before launching the
+    // kernel on the non-blocking trw->stream(); non-blocking streams do
+    // not auto-sync with the legacy null stream, so without this the
+    // kernel can observe partially written prep buffers.
+    CUDA_CHECK_AND_CLEAR(cudaStreamSynchronize(0));
+
     launch_walk_kernel_dispatch(
         kernel_launch_type, view, trw->is_directed(), walk_set_view,
         max_walk_len, repeated_node_ids.data, repeated_node_ids.size,
@@ -711,6 +718,10 @@ temporal_random_walk::get_random_walks_and_times_for_last_batch_cuda(
 
     const TemporalGraphView view = make_temporal_graph_view(trw->data());
 
+    // Drain stream-0 prep work before launching on trw->stream(); see note
+    // in the _for_all_nodes_cuda counterpart above.
+    CUDA_CHECK_AND_CLEAR(cudaStreamSynchronize(0));
+
     launch_walk_kernel_dispatch(
         kernel_launch_type, view, trw->is_directed(), walk_set_view,
         max_walk_len, repeated_node_ids.data, repeated_node_ids.size,
@@ -766,6 +777,10 @@ temporal_random_walk::get_random_walks_and_times_cuda(
     const WalkSetView walk_set_view = device_walks.make_view();
 
     const TemporalGraphView view = make_temporal_graph_view(trw->data());
+
+    // Drain stream-0 prep work before launching on trw->stream(); see note
+    // in the _for_all_nodes_cuda counterpart above.
+    CUDA_CHECK_AND_CLEAR(cudaStreamSynchronize(0));
 
     launch_walk_kernel_dispatch(
         kernel_launch_type, view, trw->is_directed(), walk_set_view,

--- a/temporal_random_walk/src/data/buffer.cuh
+++ b/temporal_random_walk/src/data/buffer.cuh
@@ -263,8 +263,18 @@ public:
         const size_t remaining = size_ - n;
 #ifdef HAS_CUDA
         if (use_gpu_) {
+            // D2D cudaMemcpy is a parallel copy kernel with no overlap
+            // guarantee — a direct shift-down would race reads against
+            // writes in the overlap region (dst < src). Bounce through a
+            // scratch buffer to keep the semantics aligned with the
+            // CPU memmove below.
+            Buffer<T> scratch(true);
+            scratch.resize(remaining);
             CUDA_CHECK_AND_CLEAR(cudaMemcpy(
-                data_, data_ + n, remaining * sizeof(T),
+                scratch.data(), data_ + n, remaining * sizeof(T),
+                cudaMemcpyDeviceToDevice));
+            CUDA_CHECK_AND_CLEAR(cudaMemcpy(
+                data_, scratch.data(), remaining * sizeof(T),
                 cudaMemcpyDeviceToDevice));
         } else
 #endif


### PR DESCRIPTION
1) Stream-0 vs trw->stream() race in walk orchestrators
   The walk-sampling prep phase (repeat_elements, shuffle_vector_device,
   WalkSetDevice::fill) issues work on the legacy null stream via
   thrust::device / cudaMemsetAsync(stream=0). trw->stream() is created
   with cudaStreamNonBlocking, which does not auto-sync with stream 0.
   Without an explicit drain, the walk kernel could observe partially
   written start_node_ids / walk buffers, giving corrupted walks in
   release builds. Debug builds masked this because CUDA_KERNEL_CHECK
   expands to cudaDeviceSynchronize there.

   Add cudaStreamSynchronize(0) immediately before the kernel launch in
   all three get_random_walks_*_cuda orchestrators.

2) Overlapping D2D cudaMemcpy in Buffer::drop_front
   D2D cudaMemcpy is a parallel copy kernel with no overlap guarantee.
   drop_front was doing a direct shift-down (dst < src), which races
   reads of src[i] against writes of dst[i+n] in the overlap region and
   is UB by CUDA semantics. This path is exercised by
   temporal_graph::delete_old_edges_cuda when max_time_capacity is
   active, so old-edge trimming could silently corrupt sources /
   targets / timestamps / edge_features.

   Bounce through a scratch Buffer<T> so src and dst never overlap.
   CPU branch already used std::memmove and is unchanged.