### PR TITLE
feat(walk): per-seed cutoff_times — sample a node's walk "as of time t"

### DIFF
--- a/temporal_random_walk/py_interface/_temporal_random_walk.cu
+++ b/temporal_random_walk/py_interface/_temporal_random_walk.cu
@@ -506,7 +506,8 @@ PYBIND11_MODULE(_temporal_random_walk, m)
                                                const int num_walks_per_node,
                                                const std::optional<std::string>& initial_edge_bias = std::nullopt,
                                                const std::string& walk_direction = "Forward_In_Time",
-                                               const std::string& kernel_launch_type = "NODE_GROUPED")
+                                               const std::string& kernel_launch_type = "NODE_GROUPED",
+                                               const std::optional<py::array_t<int64_t, py::array::c_style | py::array::forcecast>>& cutoff_times = std::nullopt)
             {
                 const RandomPickerType walk_bias_enum = picker_type_from_string(walk_bias);
                 std::optional<RandomPickerType> edge_bias_enum_opt;
@@ -523,9 +524,27 @@ PYBIND11_MODULE(_temporal_random_walk, m)
                 const int* seed_ptr = static_cast<const int*>(seed_info.ptr);
                 const auto num_seed_nodes = static_cast<size_t>(seed_info.shape[0]);
 
+                // Optional per-seed start-time cutoff. nullptr => unbounded.
+                // Each cutoff is an EXCLUSIVE upper bound: the seed's walk may
+                // only traverse edges strictly before it ("as of time t").
+                const int64_t* cutoff_ptr = nullptr;
+                py::buffer_info cutoff_info;
+                if (cutoff_times.has_value()) {
+                    cutoff_info = cutoff_times->request();
+                    if (cutoff_info.ndim != 1) {
+                        throw std::runtime_error("cutoff_times must be a 1D int64 array");
+                    }
+                    if (static_cast<size_t>(cutoff_info.shape[0]) != num_seed_nodes) {
+                        throw std::runtime_error(
+                            "cutoff_times must have the same length as seed_nodes");
+                    }
+                    cutoff_ptr = static_cast<const int64_t*>(cutoff_info.ptr);
+                }
+
                 auto walks = tw.get_random_walks_and_times_for_nodes(
                     seed_ptr,
                     num_seed_nodes,
+                    cutoff_ptr,
                     max_walk_len,
                     &walk_bias_enum,
                     num_walks_per_node,
@@ -603,6 +622,12 @@ PYBIND11_MODULE(_temporal_random_walk, m)
                 kernel_launch_type (str, optional): "NODE_GROUPED" (default),
                     "NODE_GROUPED_GLOBAL_ONLY" (ablation: coop without smem preload),
                     or "FULL_WALK" (one thread per walk, baseline).
+                cutoff_times (np.ndarray, optional): 1D int64 array, same length as
+                    seed_nodes. Each entry is an EXCLUSIVE per-seed time horizon —
+                    that seed's walks may only traverse edges with timestamp strictly
+                    less than it ("walk this node as of time t"). For backward walks
+                    this bounds the start edge (later hops are already earlier); for
+                    forward walks it caps every hop. Omit (or None) for unbounded walks.
 
             Returns:
                 Tuple[np.ndarray, np.ndarray, np.ndarray, Optional[np.ndarray]]:
@@ -618,7 +643,8 @@ PYBIND11_MODULE(_temporal_random_walk, m)
             py::arg("num_walks_per_node"),
             py::arg("initial_edge_bias") = py::none(),
             py::arg("walk_direction") = "Forward_In_Time",
-            py::arg("kernel_launch_type") = "NODE_GROUPED")
+            py::arg("kernel_launch_type") = "NODE_GROUPED",
+            py::arg("cutoff_times") = py::none())
 
         .def("get_random_walks_and_times", [](TemporalRandomWalk& tw,
                                                const int max_walk_len,

--- a/temporal_random_walk/src/common/const.cuh
+++ b/temporal_random_walk/src/common/const.cuh
@@ -12,6 +12,14 @@ constexpr int64_t EMPTY_TIMESTAMP_VALUE = -1;
 constexpr int64_t EMPTY_EDGE_ID = -1;
 constexpr uint64_t EMPTY_GLOBAL_SEED = UINT64_MAX;
 
+// Per-walk start-time cutoff sentinel: a walk whose cutoff equals this is
+// unbounded (samples from the whole graph). A real cutoff t is an EXCLUSIVE
+// upper bound — the walk may only traverse edges with timestamp < t ("walk
+// this node as of time t"). -1 is reused for parity with the existing
+// "no timestamp constraint" convention and because it is memset-friendly
+// (0xFF bytes), so default-filling a per-walk cutoff buffer is a plain fill.
+constexpr int64_t NO_WALK_CUTOFF = -1;
+
 constexpr bool DEFAULT_SHUFFLE_WALK_ORDER = true;
 
 // Temporal Node2Vec rejection-sampling retry cap.  Per-hop proposal is

--- a/temporal_random_walk/src/core/node_grouped/kernels/coop_block.cuh
+++ b/temporal_random_walk/src/core/node_grouped/kernels/coop_block.cuh
@@ -77,6 +77,7 @@ __global__ void node_grouped_block_smem_kernel(
             walk_idx * static_cast<size_t>(max_walk_len)
             + static_cast<size_t>(step_number);
         const int64_t last_ts = walk_set.timestamps[offset];
+        const int64_t cutoff  = walk_set.cutoffs[walk_idx];
 
         PhiloxState rng;
         init_philox_state(rng, base_seed, walk_idx,
@@ -89,7 +90,7 @@ __global__ void node_grouped_block_smem_kernel(
             /*node_ts_sorted_indices=*/nullptr,
             /*view_timestamps=*/nullptr,
             ptrs.weights, ptrs.weights_size,
-            node_group_begin, G, last_ts, r_group,
+            node_group_begin, G, last_ts, cutoff, r_group,
             /*s_cum_weights=*/s_cum_weights);
         if (local_pos == -1) continue;
 
@@ -179,6 +180,7 @@ __global__ void node_grouped_block_global_kernel(
             walk_idx * static_cast<size_t>(max_walk_len)
             + static_cast<size_t>(step_number);
         const int64_t last_ts = walk_set.timestamps[offset];
+        const int64_t cutoff  = walk_set.cutoffs[walk_idx];
 
         PhiloxState rng;
         init_philox_state(rng, base_seed, walk_idx,
@@ -191,7 +193,7 @@ __global__ void node_grouped_block_global_kernel(
             /*first_ts=*/nullptr,
             ptrs.node_ts_sorted_indices, view.timestamps,
             ptrs.weights, ptrs.weights_size,
-            node_group_begin, G, last_ts, r_group);
+            node_group_begin, G, last_ts, cutoff, r_group);
         if (local_pos == -1) continue;
 
         sample_edge_and_add_hop<IsDirected, Forward>(

--- a/temporal_random_walk/src/core/node_grouped/kernels/coop_warp.cuh
+++ b/temporal_random_walk/src/core/node_grouped/kernels/coop_warp.cuh
@@ -87,6 +87,7 @@ __global__ void node_grouped_warp_smem_kernel(
             walk_idx * static_cast<size_t>(max_walk_len)
             + static_cast<size_t>(step_number);
         const int64_t last_ts = walk_set.timestamps[offset];
+        const int64_t cutoff  = walk_set.cutoffs[walk_idx];
 
         PhiloxState rng;
         init_philox_state(rng, base_seed, walk_idx,
@@ -99,7 +100,7 @@ __global__ void node_grouped_warp_smem_kernel(
             /*node_ts_sorted_indices=*/nullptr,
             /*view_timestamps=*/nullptr,
             ptrs.weights, ptrs.weights_size,
-            node_group_begin, G, last_ts, r_group,
+            node_group_begin, G, last_ts, cutoff, r_group,
             /*s_cum_weights=*/s_cum_weights);
         if (local_pos == -1) continue;
 
@@ -196,6 +197,7 @@ __global__ void node_grouped_warp_global_kernel(
             walk_idx * static_cast<size_t>(max_walk_len)
             + static_cast<size_t>(step_number);
         const int64_t last_ts = walk_set.timestamps[offset];
+        const int64_t cutoff  = walk_set.cutoffs[walk_idx];
 
         PhiloxState rng;
         init_philox_state(rng, base_seed, walk_idx,
@@ -208,7 +210,7 @@ __global__ void node_grouped_warp_global_kernel(
             /*first_ts=*/nullptr,
             ptrs.node_ts_sorted_indices, view.timestamps,
             ptrs.weights, ptrs.weights_size,
-            node_group_begin, G, last_ts, r_group);
+            node_group_begin, G, last_ts, cutoff, r_group);
         if (local_pos == -1) continue;
 
         sample_edge_and_add_hop<IsDirected, Forward>(

--- a/temporal_random_walk/src/core/node_grouped/kernels/per_walk.cuh
+++ b/temporal_random_walk/src/core/node_grouped/kernels/per_walk.cuh
@@ -42,8 +42,9 @@ __global__ void pick_start_edges_kernel(
 
     InternalEdge start_edge;
     if constexpr (Constrained) {
+        const int64_t cutoff = walk_set.cutoffs[walk_idx];
         start_edge = temporal_graph::get_node_edge_at_device<Forward, StartPickerType, IsDirected>(
-            view, start_node_ids[walk_idx], /*timestamp=*/-1, /*prev=*/-1,
+            view, start_node_ids[walk_idx], /*timestamp=*/-1, cutoff, /*prev=*/-1,
             r_start_a, r_start_b);
     } else {
         start_edge = temporal_graph::get_edge_at_device<Forward, StartPickerType>(
@@ -126,6 +127,19 @@ __global__ void prepopulate_start_slot_kernel(
     const size_t group_end   = count_ts_group_per_node[node_id + 1];
     if (group_begin == group_end) return;  // dead start
 
+    // Cutoff-aware dead start: groups are sorted ascending by time, so the
+    // earliest edge lives in the first group. If even it is at/after the
+    // cutoff, no edge qualifies and step 0 would find nothing — skip slot 0
+    // so the walk stays length 0, matching the CPU / full-walk paths.
+    const int64_t cutoff = walk_set.cutoffs[walk_idx];
+    if (cutoff != NO_WALK_CUTOFF) {
+        const auto ptrs = resolve_node_dir_ptrs<IsDirected, Forward>(view);
+        const size_t first_edge = ptrs.node_ts_groups_offsets[group_begin];
+        const int64_t earliest_ts =
+            view.timestamps[ptrs.node_ts_sorted_indices[first_edge]];
+        if (earliest_ts >= cutoff) return;
+    }
+
     constexpr int64_t sentinel_timestamp = Forward ? INT64_MIN : INT64_MAX;
     walk_set.add_hop(walk_idx, node_id, sentinel_timestamp);
 }
@@ -164,6 +178,7 @@ DEVICE __forceinline__ void advance_one_walk(
 
     const int     last_node = walk_set.nodes[offset];
     const int64_t last_ts   = walk_set.timestamps[offset];
+    const int64_t cutoff    = walk_set.cutoffs[walk_idx];
     const int     prev_node = step_number > 0 ? walk_set.nodes[offset - 1] : -1;
 
     PhiloxState rng;
@@ -174,7 +189,7 @@ DEVICE __forceinline__ void advance_one_walk(
 
     const InternalEdge next_edge =
         temporal_graph::get_node_edge_at_device<Forward, EdgePickerType, IsDirected>(
-            view, last_node, last_ts, prev_node, r_a, r_b);
+            view, last_node, last_ts, cutoff, prev_node, r_a, r_b);
 
     if (next_edge.ts == -1) return;
 

--- a/temporal_random_walk/src/core/temporal_random_walk.cu
+++ b/temporal_random_walk/src/core/temporal_random_walk.cu
@@ -486,6 +486,7 @@ temporal_random_walk::get_random_walks_and_times_for_nodes_std(
     core::TemporalRandomWalk* trw,
     const int* seed_nodes,
     const size_t num_seed_nodes,
+    const int64_t* cutoff_times,
     const int max_walk_len,
     const RandomPickerType* walk_bias,
     const int num_walks_per_node,
@@ -500,13 +501,32 @@ temporal_random_walk::get_random_walks_and_times_for_nodes_std(
         seed_nodes, num_seed_nodes,
         num_walks_per_node, trw->data().use_gpu);
 
+    // Per-seed cutoffs fan out to per-walk with the same seed-major layout, so
+    // a shared-seed co-shuffle keeps each walk paired with its seed's cutoff.
+    DataBlock<int64_t> repeated_cutoffs;
+    if (cutoff_times != nullptr) {
+        repeated_cutoffs = repeat_elements(
+            cutoff_times, num_seed_nodes, num_walks_per_node, trw->data().use_gpu);
+    }
+
     if (trw->shuffle_walk_order()) {
-        shuffle_vector_host<int>(repeated_node_ids.data, repeated_node_ids.size);
+        const unsigned int shuffle_seed = std::random_device{}();
+        shuffle_vector_host<int>(
+            repeated_node_ids.data, repeated_node_ids.size, shuffle_seed);
+        if (cutoff_times != nullptr) {
+            shuffle_vector_host<int64_t>(
+                repeated_cutoffs.data, repeated_cutoffs.size, shuffle_seed);
+        }
     }
 
     WalkSetHost host_walks(repeated_node_ids.size, max_walk_len,
                            trw->walk_padding_value());
     WalkSetView walk_set_view = host_walks.make_host_view();
+
+    if (cutoff_times != nullptr) {
+        std::memcpy(walk_set_view.cutoffs, repeated_cutoffs.data,
+                    repeated_cutoffs.size * sizeof(int64_t));
+    }
 
     Buffer<double> rand_nums = generate_n_random_numbers(
         repeated_node_ids.size + repeated_node_ids.size * max_walk_len * 2, false);
@@ -760,6 +780,7 @@ temporal_random_walk::get_random_walks_and_times_for_nodes_cuda(
     core::TemporalRandomWalk* trw,
     const int* seed_nodes,
     const size_t num_seed_nodes,
+    const int64_t* cutoff_times,
     const int max_walk_len,
     const RandomPickerType* walk_bias,
     const int num_walks_per_node,
@@ -779,6 +800,14 @@ temporal_random_walk::get_random_walks_and_times_for_nodes_cuda(
         seed_nodes, num_seed_nodes,
         num_walks_per_node, trw->data().use_gpu);
 
+    // Per-seed cutoffs (host pointer) fan out to a per-walk DEVICE array with
+    // the same seed-major layout as the node ids — uploaded by repeat_elements.
+    DataBlock<int64_t> repeated_cutoffs;
+    if (cutoff_times != nullptr) {
+        repeated_cutoffs = repeat_elements(
+            cutoff_times, num_seed_nodes, num_walks_per_node, trw->data().use_gpu);
+    }
+
     const uint64_t base_seed = resolve_base_seed(trw);
 
     auto [grid_dim, launch_block_dim] = get_optimal_launch_params(
@@ -787,7 +816,14 @@ temporal_random_walk::get_random_walks_and_times_for_nodes_cuda(
         block_dim);
 
     if (trw->shuffle_walk_order()) {
-        shuffle_vector_device<int>(repeated_node_ids.data, repeated_node_ids.size);
+        const unsigned int shuffle_seed =
+            static_cast<unsigned int>(std::random_device{}());
+        shuffle_vector_device<int>(
+            repeated_node_ids.data, repeated_node_ids.size, shuffle_seed);
+        if (cutoff_times != nullptr) {
+            shuffle_vector_device<int64_t>(
+                repeated_cutoffs.data, repeated_cutoffs.size, shuffle_seed);
+        }
         CUDA_KERNEL_CHECK(
             "After shuffle_vector_device in get_random_walks_and_times_for_nodes_cuda");
     }
@@ -795,6 +831,13 @@ temporal_random_walk::get_random_walks_and_times_for_nodes_cuda(
     WalkSetDevice device_walks(repeated_node_ids.size, max_walk_len,
                                trw->walk_padding_value());
     const WalkSetView walk_set_view = device_walks.make_view();
+
+    if (cutoff_times != nullptr) {
+        CUDA_CHECK_AND_CLEAR(cudaMemcpy(
+            walk_set_view.cutoffs, repeated_cutoffs.data,
+            repeated_cutoffs.size * sizeof(int64_t),
+            cudaMemcpyDeviceToDevice));
+    }
 
     const TemporalGraphView view = make_temporal_graph_view(trw->data());
 
@@ -960,6 +1003,7 @@ WalksWithEdgeFeaturesHost
 core::TemporalRandomWalk::get_random_walks_and_times_for_nodes(
     const int* seed_nodes,
     const size_t num_seed_nodes,
+    const int64_t* cutoff_times,
     const int max_walk_len, const RandomPickerType* walk_bias,
     const int num_walks_per_node,
     const RandomPickerType* initial_edge_bias,
@@ -971,7 +1015,7 @@ core::TemporalRandomWalk::get_random_walks_and_times_for_nodes(
     CudaDeviceGuard _g(data_.use_gpu ? cuda_device_id_ : -1);
     if (data_.use_gpu) {
         return temporal_random_walk::get_random_walks_and_times_for_nodes_cuda(
-            this, seed_nodes, num_seed_nodes,
+            this, seed_nodes, num_seed_nodes, cutoff_times,
             max_walk_len, walk_bias, num_walks_per_node,
             initial_edge_bias, walk_direction, kernel_launch_type,
             block_dim, w_threshold_warp);
@@ -981,7 +1025,7 @@ core::TemporalRandomWalk::get_random_walks_and_times_for_nodes(
     (void)block_dim;
     (void)w_threshold_warp;
     return temporal_random_walk::get_random_walks_and_times_for_nodes_std(
-        this, seed_nodes, num_seed_nodes,
+        this, seed_nodes, num_seed_nodes, cutoff_times,
         max_walk_len, walk_bias, num_walks_per_node,
         initial_edge_bias, walk_direction);
 }

--- a/temporal_random_walk/src/core/temporal_random_walk.cuh
+++ b/temporal_random_walk/src/core/temporal_random_walk.cuh
@@ -115,6 +115,7 @@ public:
     WalksWithEdgeFeaturesHost get_random_walks_and_times_for_nodes(
         const int* seed_nodes,
         size_t num_seed_nodes,
+        const int64_t* cutoff_times,
         int max_walk_len,
         const RandomPickerType* walk_bias,
         int num_walks_per_node,
@@ -204,6 +205,7 @@ namespace temporal_random_walk {
         core::TemporalRandomWalk* trw,
         const int* seed_nodes,
         size_t num_seed_nodes,
+        const int64_t* cutoff_times,
         int max_walk_len,
         const RandomPickerType* walk_bias,
         int num_walks_per_node,
@@ -245,6 +247,7 @@ namespace temporal_random_walk {
         core::TemporalRandomWalk* trw,
         const int* seed_nodes,
         size_t num_seed_nodes,
+        const int64_t* cutoff_times,
         int max_walk_len,
         const RandomPickerType* walk_bias,
         int num_walks_per_node,

--- a/temporal_random_walk/src/core/temporal_random_walk_cpu.cuh
+++ b/temporal_random_walk/src/core/temporal_random_walk_cpu.cuh
@@ -32,6 +32,8 @@ namespace temporal_random_walk {
         const size_t rand_nums_start_idx_for_walk = static_cast<size_t>(walk_idx)
             + static_cast<size_t>(walk_idx) * static_cast<size_t>(max_walk_len) * 2;
 
+        const int64_t cutoff = walk_set.cutoffs[walk_idx];
+
         const auto padding_value = walk_set.nodes[walk_idx * max_walk_len];
         InternalEdge start_edge;
         if (start_node_ids[walk_idx] == -1) {
@@ -46,8 +48,9 @@ namespace temporal_random_walk {
             start_edge = temporal_graph::get_node_edge_at_host<Forward, StartPickerType, IsDirected>(
                 view,
                 start_node_ids[walk_idx],
-                -1,
-                -1,
+                /*timestamp=*/-1,
+                cutoff,
+                /*prev_node=*/-1,
                 rand_nums[rand_nums_start_idx_for_walk],
                 rand_nums[rand_nums_start_idx_for_walk + 1]
             );
@@ -98,6 +101,7 @@ namespace temporal_random_walk {
                 view,
                 current_node,
                 current_timestamp,
+                cutoff,
                 prev_node,
                 group_selector_rand_num,
                 edge_selector_rand_num

--- a/temporal_random_walk/src/core/temporal_random_walk_kernels_full_walk.cuh
+++ b/temporal_random_walk/src/core/temporal_random_walk_kernels_full_walk.cuh
@@ -36,6 +36,8 @@ namespace temporal_random_walk {
         const double r0 = draw_u01_philox(rng);
         const double r1 = draw_u01_philox(rng);
 
+        const int64_t cutoff = walk_set.cutoffs[walk_idx];
+
         const auto padding_value = walk_set.nodes[walk_idx * max_walk_len];
         InternalEdge start_edge;
         if (start_node_ids[walk_idx] == -1) {
@@ -50,8 +52,9 @@ namespace temporal_random_walk {
             start_edge = temporal_graph::get_node_edge_at_device<Forward, StartPickerType, IsDirected>(
                 view,
                 start_node_ids[walk_idx],
-                -1,
-                -1,
+                /*timestamp=*/-1,
+                cutoff,
+                /*prev_node=*/-1,
                 r0,
                 r1);
         }
@@ -101,6 +104,7 @@ namespace temporal_random_walk {
                 view,
                 current_node,
                 current_timestamp,
+                cutoff,
                 prev_node,
                 r_step0,
                 r_step1);

--- a/temporal_random_walk/src/data/walk_set/walk_set_device.cu
+++ b/temporal_random_walk/src/data/walk_set/walk_set_device.cu
@@ -9,6 +9,7 @@ WalkSetDevice::WalkSetDevice(const size_t num_walks,
                              const size_t max_len,
                              const int walk_padding_value)
     : nodes_(true), timestamps_(true), walk_lens_(true), edge_ids_(true),
+      cutoffs_(true),
       num_walks_(num_walks), max_len_(max_len),
       walk_padding_value_(walk_padding_value) {
 
@@ -19,11 +20,13 @@ WalkSetDevice::WalkSetDevice(const size_t num_walks,
     timestamps_.resize(total);
     walk_lens_.resize(num_walks);
     edge_ids_.resize(edge_total);
+    cutoffs_.resize(num_walks);
 
     nodes_.fill(walk_padding_value);
     timestamps_.fill(EMPTY_TIMESTAMP_VALUE);
     walk_lens_.fill(static_cast<size_t>(0));
     edge_ids_.fill(EMPTY_EDGE_ID);
+    cutoffs_.fill(NO_WALK_CUTOFF);
 }
 
 WalkSetView WalkSetDevice::make_view() {
@@ -32,6 +35,7 @@ WalkSetView WalkSetDevice::make_view() {
     v.timestamps         = timestamps_.data();
     v.walk_lens          = walk_lens_.data();
     v.edge_ids           = edge_ids_.data();
+    v.cutoffs            = cutoffs_.data();
     v.num_walks          = num_walks_;
     v.max_len            = max_len_;
     v.walk_padding_value = walk_padding_value_;

--- a/temporal_random_walk/src/data/walk_set/walk_set_device.cuh
+++ b/temporal_random_walk/src/data/walk_set/walk_set_device.cuh
@@ -38,6 +38,7 @@ private:
     Buffer<int64_t> timestamps_{true};
     Buffer<size_t>  walk_lens_{true};
     Buffer<int64_t> edge_ids_{true};
+    Buffer<int64_t> cutoffs_{true};   // per-walk start-time cutoff (generation scratch)
 
     size_t num_walks_          = 0;
     size_t max_len_            = 0;

--- a/temporal_random_walk/src/data/walk_set/walk_set_host.cu
+++ b/temporal_random_walk/src/data/walk_set/walk_set_host.cu
@@ -20,11 +20,13 @@ WalkSetHost::WalkSetHost(const size_t num_walks,
     timestamps_.resize(total);
     walk_lens_.resize(num_walks);
     edge_ids_.resize(edge_total);
+    cutoffs_.resize(num_walks);
 
     nodes_.fill(walk_padding_value);
     timestamps_.fill(EMPTY_TIMESTAMP_VALUE);
     walk_lens_.fill(static_cast<size_t>(0));
     edge_ids_.fill(EMPTY_EDGE_ID);
+    cutoffs_.fill(NO_WALK_CUTOFF);
 }
 
 size_t WalkSetHost::non_empty_count() const noexcept {

--- a/temporal_random_walk/src/data/walk_set/walk_set_host.cuh
+++ b/temporal_random_walk/src/data/walk_set/walk_set_host.cuh
@@ -76,6 +76,7 @@ public:
         v.timestamps         = timestamps_.data();
         v.walk_lens          = walk_lens_.data();
         v.edge_ids           = edge_ids_.data();
+        v.cutoffs            = cutoffs_.data();
         v.num_walks          = num_walks_;
         v.max_len            = max_len_;
         v.walk_padding_value = walk_padding_value_;
@@ -87,6 +88,7 @@ private:
     Buffer<int64_t> timestamps_{false};
     Buffer<size_t>  walk_lens_{false};
     Buffer<int64_t> edge_ids_{false};
+    Buffer<int64_t> cutoffs_{false};   // per-walk start-time cutoff (host generation scratch)
 
     size_t num_walks_          = 0;
     size_t max_len_            = 0;

--- a/temporal_random_walk/src/data/walk_set/walk_set_view.cuh
+++ b/temporal_random_walk/src/data/walk_set/walk_set_view.cuh
@@ -14,6 +14,11 @@ struct WalkSetView {
     size_t*  walk_lens;
     int64_t* edge_ids;
 
+    // Per-walk exclusive start-time cutoff (length num_walks). NO_WALK_CUTOFF
+    // = unbounded. Read by the edge selectors at every hop; it is in-progress
+    // walk state (the walk's time horizon), not part of the released output.
+    int64_t* cutoffs;
+
     size_t num_walks;
     size_t max_len;
     int    walk_padding_value;

--- a/temporal_random_walk/src/graph/edge_selectors.cuh
+++ b/temporal_random_walk/src/graph/edge_selectors.cuh
@@ -52,6 +52,16 @@ namespace temporal_graph {
     // slice-parameterized stage-1 helpers; positions are local to the slice [0, G).
     // first_ts non-null = single-indirect probe (cooperative kernels preload smem);
     // null = double-indirect fallback used by solo/host callers.
+    // Restrict a node's timestamp groups [0, G) to the slice a walk may sample.
+    //   timestamp : the previous hop's time (monotonic walk bound). -1 = none
+    //               (start hop). Forward keeps groups with ts > timestamp;
+    //               Backward keeps groups with ts < timestamp.
+    //   cutoff    : per-walk EXCLUSIVE upper bound on edge time (NO_WALK_CUTOFF
+    //               = unbounded). Applies in BOTH directions — it always drops
+    //               groups with ts >= cutoff, i.e. trims out_valid_end. This is
+    //               what realises "walk this node as of time t": forward it caps
+    //               every hop below t; backward it only bites on the start hop
+    //               (later hops are already earlier than t by monotonicity).
     template <bool Forward>
     HOST DEVICE inline void filter_valid_groups_by_timestamp_slice(
         const size_t*  group_offsets,
@@ -60,33 +70,50 @@ namespace temporal_graph {
         const int64_t* view_timestamps,
         const int      G,
         const int64_t  timestamp,
+        const int64_t  cutoff,
         int&           out_valid_begin,
         int&           out_valid_end) {
 
         out_valid_begin = 0;
         out_valid_end   = G;
 
-        if (timestamp == -1) return;
+        if (timestamp == -1 && cutoff == NO_WALK_CUTOFF) return;
 
         auto ts_of = [&](const int p) -> int64_t {
             if (first_ts != nullptr) return first_ts[p];
             return view_timestamps[node_ts_sorted_indices[group_offsets[p]]];
         };
 
-        if constexpr (Forward) {
-            int lo = 0, hi = G;
-            while (lo < hi) {
-                const int mid = lo + ((hi - lo) >> 1);
-                if (timestamp < ts_of(mid)) hi = mid;
-                else                         lo = mid + 1;
+        // Directional monotonic bound from the previous hop's timestamp.
+        if (timestamp != -1) {
+            if constexpr (Forward) {
+                int lo = 0, hi = G;
+                while (lo < hi) {
+                    const int mid = lo + ((hi - lo) >> 1);
+                    if (timestamp < ts_of(mid)) hi = mid;
+                    else                         lo = mid + 1;
+                }
+                out_valid_begin = lo;
+            } else {
+                int lo = 0, hi = G;
+                while (lo < hi) {
+                    const int mid = lo + ((hi - lo) >> 1);
+                    if (ts_of(mid) < timestamp) lo = mid + 1;
+                    else                          hi = mid;
+                }
+                out_valid_end = lo;
             }
-            out_valid_begin = lo;
-        } else {
-            int lo = 0, hi = G;
+        }
+
+        // Universal cutoff: exclude every group with ts >= cutoff. Search the
+        // first such group within the surviving slice and pull out_valid_end
+        // down to it (a no-op when the slice is already entirely below cutoff).
+        if (cutoff != NO_WALK_CUTOFF) {
+            int lo = out_valid_begin, hi = out_valid_end;
             while (lo < hi) {
                 const int mid = lo + ((hi - lo) >> 1);
-                if (ts_of(mid) < timestamp) lo = mid + 1;
-                else                          hi = mid;
+                if (ts_of(mid) < cutoff) lo = mid + 1;
+                else                      hi = mid;
             }
             out_valid_end = lo;
         }
@@ -107,6 +134,7 @@ namespace temporal_graph {
         const size_t   slice_global_begin,
         const int      G,
         const int64_t  timestamp,
+        const int64_t  cutoff,
         const double   r_group,
         const double*  s_cum_weights = nullptr) {
 
@@ -115,7 +143,7 @@ namespace temporal_graph {
         filter_valid_groups_by_timestamp_slice<Forward>(
             group_offsets, first_ts,
             node_ts_sorted_indices, view_timestamps,
-            G, timestamp,
+            G, timestamp, cutoff,
             valid_begin, valid_end);
         if (valid_begin >= valid_end) return -1;
 
@@ -251,6 +279,7 @@ namespace temporal_graph {
         const TemporalGraphView& view,
         const int node_id,
         const int64_t timestamp,
+        const int64_t cutoff,
         const int prev_node,
         const double group_selector_rand_num,
         const double edge_selector_rand_num) {
@@ -326,7 +355,7 @@ namespace temporal_graph {
                 /*first_ts=*/nullptr,
                 node_ts_sorted_indices,
                 view.timestamps,
-                G, timestamp,
+                G, timestamp, cutoff,
                 local_begin, local_end);
             if (local_begin >= local_end) {
                 return InternalEdge{-1, -1, -1, -1};
@@ -376,7 +405,7 @@ namespace temporal_graph {
                 view.timestamps,
                 weights, weights_size,
                 node_group_begin,
-                G, timestamp,
+                G, timestamp, cutoff,
                 group_selector_rand_num);
             if (local_pos == -1) {
                 return InternalEdge{-1, -1, -1, -1};
@@ -553,6 +582,7 @@ namespace temporal_graph {
         const TemporalGraphView& view,
         const int node_id,
         const int64_t timestamp,
+        const int64_t cutoff,
         const int prev_node,
         const double group_selector_rand_num,
         const double edge_selector_rand_num) {
@@ -621,9 +651,9 @@ namespace temporal_graph {
         // and a per-probe runtime branch on first_ts. solo/host hot path.
         size_t valid_begin = node_group_begin;
         size_t valid_end = node_group_end;
+        const int64_t* view_timestamps = view.timestamps;
 
         if (timestamp != -1) {
-            const int64_t* view_timestamps = view.timestamps;
             if constexpr (Forward) {
                 const auto it = cuda::std::upper_bound(
                     node_ts_groups_offsets + static_cast<long>(node_group_begin),
@@ -634,7 +664,6 @@ namespace temporal_graph {
                     });
 
                 valid_begin = static_cast<size_t>(it - node_ts_groups_offsets);
-                valid_end = node_group_end;
             } else {
                 const auto it = cuda::std::lower_bound(
                     node_ts_groups_offsets + static_cast<long>(node_group_begin),
@@ -644,13 +673,27 @@ namespace temporal_graph {
                         return view_timestamps[node_ts_sorted_indices[pos]] < ts;
                     });
 
-                valid_begin = node_group_begin;
                 valid_end = static_cast<size_t>(it - node_ts_groups_offsets);
             }
+        }
 
-            if (valid_begin >= valid_end) {
-                return InternalEdge{-1, -1, -1, -1};
-            }
+        // Universal cutoff: drop groups with ts >= cutoff (exclusive upper
+        // bound). lower_bound over the surviving slice → first group at/after
+        // the cutoff; pull valid_end down to it.
+        if (cutoff != NO_WALK_CUTOFF) {
+            const auto it = cuda::std::lower_bound(
+                node_ts_groups_offsets + static_cast<long>(valid_begin),
+                node_ts_groups_offsets + static_cast<long>(valid_end),
+                cutoff,
+                [view_timestamps, node_ts_sorted_indices](const size_t pos, const int64_t ts) {
+                    return view_timestamps[node_ts_sorted_indices[pos]] < ts;
+                });
+
+            valid_end = static_cast<size_t>(it - node_ts_groups_offsets);
+        }
+
+        if (valid_begin >= valid_end) {
+            return InternalEdge{-1, -1, -1, -1};
         }
 
         long group_pos = -1;

--- a/temporal_random_walk/src/proxies/TemporalRandomWalk.cu
+++ b/temporal_random_walk/src/proxies/TemporalRandomWalk.cu
@@ -69,6 +69,7 @@ TemporalRandomWalk::get_random_walks_and_times_for_last_batch(
 WalksWithEdgeFeaturesHost
 TemporalRandomWalk::get_random_walks_and_times_for_nodes(
     const int* seed_nodes, const size_t num_seed_nodes,
+    const int64_t* cutoff_times,
     const int max_walk_len, const RandomPickerType* walk_bias,
     const int num_walks_per_node,
     const RandomPickerType* initial_edge_bias,
@@ -77,7 +78,7 @@ TemporalRandomWalk::get_random_walks_and_times_for_nodes(
     const size_t block_dim,
     const int w_threshold_warp) const {
     return impl_->get_random_walks_and_times_for_nodes(
-        seed_nodes, num_seed_nodes,
+        seed_nodes, num_seed_nodes, cutoff_times,
         max_walk_len, walk_bias, num_walks_per_node,
         initial_edge_bias, walk_direction, kernel_launch_type,
         block_dim, w_threshold_warp);

--- a/temporal_random_walk/src/proxies/TemporalRandomWalk.cuh
+++ b/temporal_random_walk/src/proxies/TemporalRandomWalk.cuh
@@ -73,6 +73,7 @@ public:
 
     WalksWithEdgeFeaturesHost get_random_walks_and_times_for_nodes(
         const int* seed_nodes, size_t num_seed_nodes,
+        const int64_t* cutoff_times,
         int max_walk_len, const RandomPickerType* walk_bias,
         int num_walks_per_node,
         const RandomPickerType* initial_edge_bias = nullptr,

--- a/temporal_random_walk/src/utils/random.cuh
+++ b/temporal_random_walk/src/utils/random.cuh
@@ -29,21 +29,37 @@ HOST DEVICE inline int pick_random_number(const int a, const int b, const double
     return generate_random_boolean(rand_number) ? a : b;
 }
 
+// Seeded overload: std::shuffle's swap sequence depends only on the RNG and
+// the range length, not the element type — so calling this with the SAME seed
+// and SAME size on two parallel arrays applies the identical permutation to
+// both (used to co-shuffle walk seeds and their per-walk cutoffs).
+template <typename T>
+HOST void shuffle_vector_host(T* vec, size_t size, unsigned int seed) {
+    std::mt19937 rng(seed);
+    std::shuffle(vec, vec + size, rng);
+}
+
 template <typename T>
 HOST void shuffle_vector_host(T* vec, size_t size) {
     std::random_device rd;
-    std::mt19937 rng(rd());
-    std::shuffle(vec, vec + size, rng);
+    shuffle_vector_host(vec, size, rd());
 }
 
 #ifdef HAS_CUDA
 
+// Seeded overload — same-seed/same-size ⇒ identical permutation across arrays,
+// regardless of element type (parallel-array co-shuffle on device).
+template <typename T>
+HOST void shuffle_vector_device(T* data, size_t size, unsigned int seed) {
+    thrust::device_ptr<T> d_data(data);
+    thrust::default_random_engine random_engine(seed);
+    thrust::shuffle(DEVICE_EXECUTION_POLICY, d_data, d_data + size, random_engine);
+    CUDA_KERNEL_CHECK("After thrust shuffle in shuffle_vector_device (seeded)");
+}
+
 template <typename T>
 HOST void shuffle_vector_device(T* data, size_t size) {
-    thrust::device_ptr<T> d_data(data);
-    thrust::default_random_engine random_engine(static_cast<unsigned int>(std::time(nullptr)));
-    thrust::shuffle(DEVICE_EXECUTION_POLICY, d_data, d_data + size, random_engine);
-    CUDA_KERNEL_CHECK("After thrust shuffle in shuffle_vector_device");
+    shuffle_vector_device(data, size, static_cast<unsigned int>(std::time(nullptr)));
 }
 
 #endif

--- a/temporal_random_walk/src/utils/utils.cuh
+++ b/temporal_random_walk/src/utils/utils.cuh
@@ -54,19 +54,24 @@ HOST inline DataBlock<int> repeat_elements(const DataBlock<int>& arr, int times,
     return repeated_items;
 }
 
-HOST inline DataBlock<int> repeat_elements(const int* arr, const size_t input_size, int times, const bool use_gpu) {
+// Element-type-generic: each of `input_size` elements is repeated `times`
+// contiguously (seed-major). Used for per-walk node ids (int) and per-walk
+// start-time cutoffs (int64_t), which must fan out with identical layout so a
+// shared-seed co-shuffle keeps them aligned.
+template <typename T>
+HOST inline DataBlock<T> repeat_elements(const T* arr, const size_t input_size, int times, const bool use_gpu) {
     const size_t output_size = input_size * times;
 
-    DataBlock<int> repeated_items(output_size, use_gpu);
+    DataBlock<T> repeated_items(output_size, use_gpu);
     if (input_size == 0 || times <= 0) {
         return repeated_items;
     }
 
     #ifdef HAS_CUDA
     if (use_gpu) {
-        Buffer<int> d_arr_buf(input_size, true);
-        int* d_arr = d_arr_buf.data();
-        CUDA_CHECK_AND_CLEAR(cudaMemcpy(d_arr, arr, input_size * sizeof(int), cudaMemcpyHostToDevice));
+        Buffer<T> d_arr_buf(input_size, true);
+        T* d_arr = d_arr_buf.data();
+        CUDA_CHECK_AND_CLEAR(cudaMemcpy(d_arr, arr, input_size * sizeof(T), cudaMemcpyHostToDevice));
 
         thrust::transform(
             DEVICE_EXECUTION_POLICY,

--- a/temporal_random_walk/test/CMakeLists.txt
+++ b/temporal_random_walk/test/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TEST_FILES
         test_node_grouped_g_partition.cpp
         test_node_grouped_block_task_expansion.cpp
         test_node_grouped_walk_tier_routing.cpp
+        test_walk_cutoff_times.cpp
 )
 
 set(MODULE_SRC_FILES ${SRC_FILES} ${TEST_FILES})

--- a/temporal_random_walk/test/test_temporal_graph_utils.h
+++ b/temporal_random_walk/test/test_temporal_graph_utils.h
@@ -33,10 +33,11 @@ __global__ void get_edge_at_kernel(
 template <bool IsDirected, bool Forward, RandomPickerType PickerType>
 __global__ void get_node_edge_at_kernel(
     Edge* result, TemporalGraphView view, const int node_id,
-    const int64_t timestamp, const int prev_node, const double* rand_nums) {
+    const int64_t timestamp, const int64_t cutoff, const int prev_node,
+    const double* rand_nums) {
     if (threadIdx.x == 0 && blockIdx.x == 0) {
         *result = temporal_graph::get_node_edge_at_device<Forward, PickerType, IsDirected>(
-            view, node_id, timestamp, prev_node, rand_nums[0], rand_nums[1]);
+            view, node_id, timestamp, cutoff, prev_node, rand_nums[0], rand_nums[1]);
     }
 }
 
@@ -136,7 +137,8 @@ inline Edge get_node_edge_at(
     const RandomPickerType picker_type,
     const int64_t timestamp,
     const int prev_node,
-    const bool forward = true) {
+    const bool forward = true,
+    const int64_t cutoff = NO_WALK_CUTOFF) {
     const TemporalGraphView view = make_temporal_graph_view(data);
     Edge result{};
     const bool is_directed = data.is_directed;
@@ -146,12 +148,12 @@ inline Edge get_node_edge_at(
 
     #define DISPATCH_HOST(FWD, PICKER, DIR) \
         result = temporal_graph::get_node_edge_at_host<FWD, PICKER, DIR>( \
-            view, node_id, timestamp, prev_node, rand_nums[0], rand_nums[1]); break;
+            view, node_id, timestamp, cutoff, prev_node, rand_nums[0], rand_nums[1]); break;
 
 #ifdef HAS_CUDA
     #define DISPATCH_DEVICE(FWD, PICKER, DIR) \
         test_util_detail::get_node_edge_at_kernel<DIR, FWD, PICKER><<<1, 1>>>( \
-            d_result, view, node_id, timestamp, prev_node, rand_nums); \
+            d_result, view, node_id, timestamp, cutoff, prev_node, rand_nums); \
         CUDA_KERNEL_CHECK("get_node_edge_at_kernel"); break;
 #endif
 

--- a/temporal_random_walk/test/test_walk_cutoff_times.cpp
+++ b/temporal_random_walk/test/test_walk_cutoff_times.cpp
@@ -1,0 +1,474 @@
+// Tests for the per-seed `cutoff_times` walk parameter.
+//
+// A cutoff is an EXCLUSIVE upper bound on edge time: a seed's walk may only
+// traverse edges with timestamp strictly less than its cutoff ("walk this node
+// as of time t"). For backward walks this only binds the start edge (later hops
+// are already earlier, by monotonicity); for forward walks it caps every hop.
+// NO_WALK_CUTOFF (-1) means unbounded.
+//
+// Three layers are exercised, all paired CPU/GPU via GPU_USAGE_TYPES (the
+// CPU/GPU pairing rule in test/CPU_GPU_PAIRING.md), and across both
+// directions and all three execution paths (CPU _std, FULL_WALK, NODE_GROUPED
+// coop/solo):
+//   1. Selector  — deterministic exact-pick checks of the cutoff filter through
+//                  test_util::get_node_edge_at (TEST_FIRST / TEST_LAST pickers).
+//   2. Walk      — property checks on whole walks (every real edge < cutoff,
+//                  heterogeneous per-seed cutoffs, empty/unbounded edge cases).
+//   3. Parity    — every kernel (NODE_GROUPED tiers + FULL_WALK) honours the
+//                  cutoff identically, including on a high-degree hub seed.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <vector>
+
+#include "test_utils.h"
+#include "test_temporal_graph_utils.h"
+#include "../src/common/const.cuh"
+#include "../src/data/enums.cuh"
+#include "../src/proxies/TemporalRandomWalk.cuh"
+
+namespace {
+
+constexpr int      MAX_WALK_LEN       = 20;
+constexpr int      NUM_WALKS_PER_NODE = 8;
+constexpr uint64_t CUTOFF_SEED        = 0xC0FFEE1234ULL;
+
+constexpr int64_t kSentinelMax = std::numeric_limits<int64_t>::max();
+constexpr int64_t kSentinelMin = std::numeric_limits<int64_t>::min();
+
+constexpr RandomPickerType kExpWeight = RandomPickerType::ExponentialWeight;
+
+#ifdef HAS_CUDA
+using GPU_USAGE_TYPES = ::testing::Types<
+    std::integral_constant<bool, false>,
+    std::integral_constant<bool, true>
+>;
+#else
+using GPU_USAGE_TYPES = ::testing::Types<
+    std::integral_constant<bool, false>
+>;
+#endif
+
+// The seed slot carries a direction-dependent sentinel timestamp, never a real
+// edge time — skip it in cutoff assertions.
+inline bool is_real_edge_ts(const int64_t ts) {
+    return ts != kSentinelMax && ts != kSentinelMin && ts != EMPTY_TIMESTAMP_VALUE;
+}
+
+// Walk w (rows are seed-major; shuffle_walk_order is off) belongs to seed
+// w / num_walks_per_node, hence to that seed's cutoff.
+void expect_every_edge_before_cutoff(
+    const WalksWithEdgeFeaturesHost& walks,
+    const std::vector<int64_t>& seed_cutoffs,
+    const int num_walks_per_node) {
+    const auto& ws = walks.walk_set;
+    const size_t* lens = ws.walk_lens_ptr();
+    const int64_t* ts  = ws.timestamps_ptr();
+    const size_t max_len = ws.max_len();
+
+    for (size_t w = 0; w < ws.num_walks(); ++w) {
+        const int64_t cutoff = seed_cutoffs[w / num_walks_per_node];
+        if (cutoff == NO_WALK_CUTOFF) continue;
+        for (size_t p = 0; p < lens[w]; ++p) {
+            const int64_t t = ts[w * max_len + p];
+            if (!is_real_edge_ts(t)) continue;
+            EXPECT_LT(t, cutoff)
+                << "walk " << w << " (seed-slot " << (w / num_walks_per_node)
+                << ") hop " << p << " has edge time >= its cutoff";
+        }
+    }
+}
+
+size_t total_real_hops(const WalksWithEdgeFeaturesHost& walks) {
+    const auto& ws = walks.walk_set;
+    const size_t* lens = ws.walk_lens_ptr();
+    size_t total = 0;
+    for (size_t w = 0; w < ws.num_walks(); ++w) total += lens[w];
+    return total;
+}
+
+void expect_walks_bit_identical(
+    const WalksWithEdgeFeaturesHost& a,
+    const WalksWithEdgeFeaturesHost& b) {
+    const auto& wa = a.walk_set;
+    const auto& wb = b.walk_set;
+    ASSERT_EQ(wa.num_walks(), wb.num_walks());
+    ASSERT_EQ(wa.max_len(),   wb.max_len());
+
+    const size_t*  la = wa.walk_lens_ptr();
+    const size_t*  lb = wb.walk_lens_ptr();
+    const int*     na = wa.nodes_ptr();
+    const int*     nb = wb.nodes_ptr();
+    const int64_t* ta = wa.timestamps_ptr();
+    const int64_t* tb = wb.timestamps_ptr();
+    const size_t   max_len = wa.max_len();
+
+    for (size_t w = 0; w < wa.num_walks(); ++w) {
+        ASSERT_EQ(la[w], lb[w]) << "walk " << w << " length differs";
+        for (size_t p = 0; p < la[w]; ++p) {
+            const size_t idx = w * max_len + p;
+            EXPECT_EQ(na[idx], nb[idx]) << "walk " << w << " node@" << p;
+            EXPECT_EQ(ta[idx], tb[idx]) << "walk " << w << " ts@"   << p;
+        }
+    }
+}
+
+std::unique_ptr<TemporalRandomWalk> make_trw(const bool use_gpu, const bool is_directed) {
+    return std::make_unique<TemporalRandomWalk>(
+        is_directed,
+        use_gpu,
+        /*max_time_capacity=*/-1,
+        /*enable_weight_computation=*/true,
+        /*enable_temporal_node2vec=*/false,
+        DEFAULT_TIMESCALE_BOUND,
+        DEFAULT_NODE2VEC_P,
+        DEFAULT_NODE2VEC_Q,
+        EMPTY_NODE_VALUE,
+        /*global_seed=*/CUTOFF_SEED,
+        /*shuffle_walk_order=*/false);
+}
+
+// =====================================================================
+// Layer 1 — selector level (deterministic cutoff filter)
+// =====================================================================
+
+template<typename T>
+class CutoffSelectorTest : public ::testing::Test {
+protected:
+    std::unique_ptr<core::TemporalRandomWalk> graph;
+    void SetUp() override {
+        graph = std::make_unique<core::TemporalRandomWalk>(/*is_directed=*/true, T::value);
+    }
+    TemporalGraphData& data() { return graph->data(); }
+
+    static void expect_edge(const Edge& e, int u, int i, int64_t ts) {
+        EXPECT_EQ(e.u, u);
+        EXPECT_EQ(e.i, i);
+        EXPECT_EQ(e.ts, ts);
+    }
+    static void expect_invalid(const Edge& e) {
+        EXPECT_EQ(e.u, -1);
+        EXPECT_EQ(e.i, -1);
+        EXPECT_EQ(e.ts, -1);
+    }
+};
+
+TYPED_TEST_SUITE(CutoffSelectorTest, GPU_USAGE_TYPES);
+
+// Forward: cutoff is an upper bound on the picked edge (ts < cutoff), on top of
+// the existing lower bound from `timestamp` (ts > timestamp).
+TYPED_TEST(CutoffSelectorTest, ForwardCutoffUpperBound) {
+    test_util::add_edges(*this->graph, {
+        Edge{10, 20, 100}, Edge{10, 30, 101}, Edge{10, 40, 102},
+        Edge{10, 50, 103}, Edge{10, 60, 104},
+    });
+    const auto& d = this->data();
+    using RP = RandomPickerType;
+    constexpr bool FWD = true;
+
+    // No cutoff: full range.
+    this->expect_edge(test_util::get_node_edge_at(d, 10, RP::TEST_FIRST, -1, -1, FWD, NO_WALK_CUTOFF), 10, 20, 100);
+    this->expect_edge(test_util::get_node_edge_at(d, 10, RP::TEST_LAST,  -1, -1, FWD, NO_WALK_CUTOFF), 10, 60, 104);
+
+    // Cutoff trims the upper end (exclusive): ts < 104 ⇒ latest valid is 103.
+    this->expect_edge(test_util::get_node_edge_at(d, 10, RP::TEST_LAST,  -1, -1, FWD, /*cutoff=*/104), 10, 50, 103);
+    this->expect_edge(test_util::get_node_edge_at(d, 10, RP::TEST_LAST,  -1, -1, FWD, /*cutoff=*/103), 10, 40, 102);
+    this->expect_edge(test_util::get_node_edge_at(d, 10, RP::TEST_FIRST, -1, -1, FWD, /*cutoff=*/101), 10, 20, 100);
+
+    // Cutoff at/below the earliest edge excludes everything.
+    this->expect_invalid(test_util::get_node_edge_at(d, 10, RP::TEST_FIRST, -1, -1, FWD, /*cutoff=*/100));
+    this->expect_invalid(test_util::get_node_edge_at(d, 10, RP::TEST_FIRST, -1, -1, FWD, /*cutoff=*/50));
+
+    // Cutoff above the latest edge is a no-op (same as unbounded).
+    this->expect_edge(test_util::get_node_edge_at(d, 10, RP::TEST_LAST,  -1, -1, FWD, /*cutoff=*/1000), 10, 60, 104);
+}
+
+// Forward: cutoff (upper) composes with the monotonic lower bound `timestamp`.
+TYPED_TEST(CutoffSelectorTest, ForwardCutoffWithTimestampWindow) {
+    test_util::add_edges(*this->graph, {
+        Edge{10, 20, 100}, Edge{10, 30, 101}, Edge{10, 40, 102},
+        Edge{10, 50, 103}, Edge{10, 60, 104},
+    });
+    const auto& d = this->data();
+    using RP = RandomPickerType;
+    constexpr bool FWD = true;
+
+    // ts > 101 AND ts < 104  ⇒ {102, 103}.
+    this->expect_edge(test_util::get_node_edge_at(d, 10, RP::TEST_FIRST, 101, -1, FWD, /*cutoff=*/104), 10, 40, 102);
+    this->expect_edge(test_util::get_node_edge_at(d, 10, RP::TEST_LAST,  101, -1, FWD, /*cutoff=*/104), 10, 50, 103);
+    // Window collapses to a single edge.
+    this->expect_edge(test_util::get_node_edge_at(d, 10, RP::TEST_FIRST, 101, -1, FWD, /*cutoff=*/103), 10, 40, 102);
+    // Empty window (lower >= upper-1).
+    this->expect_invalid(test_util::get_node_edge_at(d, 10, RP::TEST_FIRST, 102, -1, FWD, /*cutoff=*/103));
+}
+
+// Backward: cutoff is an upper bound (ts < cutoff) that combines with the
+// existing backward upper bound from `timestamp` via min().
+TYPED_TEST(CutoffSelectorTest, BackwardCutoffUpperBound) {
+    test_util::add_edges(*this->graph, {
+        Edge{20, 10, 100}, Edge{30, 10, 101}, Edge{40, 10, 102},
+        Edge{50, 10, 103}, Edge{60, 10, 104},
+    });
+    const auto& d = this->data();
+    using RP = RandomPickerType;
+    constexpr bool BWD = false;
+
+    // No cutoff.
+    this->expect_edge(test_util::get_node_edge_at(d, 10, RP::TEST_FIRST, -1, -1, BWD, NO_WALK_CUTOFF), 20, 10, 100);
+    this->expect_edge(test_util::get_node_edge_at(d, 10, RP::TEST_LAST,  -1, -1, BWD, NO_WALK_CUTOFF), 60, 10, 104);
+
+    // Cutoff trims the latest predecessors (exclusive).
+    this->expect_edge(test_util::get_node_edge_at(d, 10, RP::TEST_LAST,  -1, -1, BWD, /*cutoff=*/104), 50, 10, 103);
+    this->expect_edge(test_util::get_node_edge_at(d, 10, RP::TEST_LAST,  -1, -1, BWD, /*cutoff=*/102), 30, 10, 101);
+    this->expect_edge(test_util::get_node_edge_at(d, 10, RP::TEST_FIRST, -1, -1, BWD, /*cutoff=*/101), 20, 10, 100);
+
+    // Exclude all / no-op above max.
+    this->expect_invalid(test_util::get_node_edge_at(d, 10, RP::TEST_FIRST, -1, -1, BWD, /*cutoff=*/100));
+    this->expect_edge(test_util::get_node_edge_at(d, 10, RP::TEST_LAST,  -1, -1, BWD, /*cutoff=*/1000), 60, 10, 104);
+
+    // min(timestamp, cutoff): both upper bounds, the tighter wins.
+    this->expect_edge(test_util::get_node_edge_at(d, 10, RP::TEST_LAST,  103, -1, BWD, /*cutoff=*/102), 30, 10, 101);
+    this->expect_edge(test_util::get_node_edge_at(d, 10, RP::TEST_LAST,  102, -1, BWD, /*cutoff=*/103), 30, 10, 101);
+}
+
+// The cutoff is exclusive: an edge exactly at the cutoff is dropped.
+TYPED_TEST(CutoffSelectorTest, CutoffBoundaryIsExclusive) {
+    test_util::add_edges(*this->graph, {
+        Edge{10, 20, 100}, Edge{10, 30, 110}, Edge{10, 40, 120},  // outbound
+        Edge{50, 70, 100}, Edge{60, 70, 110}, Edge{80, 70, 120},  // inbound to 70
+    });
+    const auto& d = this->data();
+    using RP = RandomPickerType;
+
+    // Forward, cutoff == 110 ⇒ only ts 100 survives.
+    this->expect_edge(test_util::get_node_edge_at(d, 10, RP::TEST_LAST, -1, -1, true,  /*cutoff=*/110), 10, 20, 100);
+    // Backward, cutoff == 110 ⇒ only ts 100 survives.
+    this->expect_edge(test_util::get_node_edge_at(d, 70, RP::TEST_LAST, -1, -1, false, /*cutoff=*/110), 50, 70, 100);
+}
+
+// =====================================================================
+// Layer 2 — whole-walk properties
+// =====================================================================
+
+template<typename T>
+class CutoffWalkTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        sample_edges = read_edges_from_csv(sample_data_path());
+        int64_t lo = std::numeric_limits<int64_t>::max();
+        int64_t hi = std::numeric_limits<int64_t>::min();
+        for (const auto& [u, v, ts] : sample_edges) {
+            lo = std::min(lo, ts);
+            hi = std::max(hi, ts);
+        }
+        ts_min = lo;
+        ts_max = hi;
+    }
+
+    std::unique_ptr<TemporalRandomWalk> trw(const bool is_directed) const {
+        auto t = make_trw(T::value, is_directed);
+        t->add_multiple_edges(sample_edges);
+        return t;
+    }
+
+    WalksWithEdgeFeaturesHost run(
+        TemporalRandomWalk& t,
+        const std::vector<int>& seeds,
+        const std::vector<int64_t>& cutoffs,
+        const WalkDirection dir,
+        const RandomPickerType picker,
+        const KernelLaunchType klt,
+        const int64_t* cutoff_ptr_override = nullptr) const {
+        const int64_t* cptr = cutoff_ptr_override
+            ? cutoff_ptr_override
+            : (cutoffs.empty() ? nullptr : cutoffs.data());
+        return t.get_random_walks_and_times_for_nodes(
+            seeds.data(), seeds.size(), cptr,
+            MAX_WALK_LEN, &picker, NUM_WALKS_PER_NODE,
+            /*initial_edge_bias=*/nullptr, dir, klt);
+    }
+
+    std::vector<std::tuple<int, int, int64_t>> sample_edges;
+    int64_t ts_min = 0;
+    int64_t ts_max = 0;
+};
+
+TYPED_TEST_SUITE(CutoffWalkTest, GPU_USAGE_TYPES);
+
+TYPED_TEST(CutoffWalkTest, BackwardEveryEdgeBeforeCutoff) {
+    auto t = this->trw(/*is_directed=*/true);
+    const std::vector<int> seeds = {109, 41, 15, 7, 88};
+    const int64_t mid = this->ts_min + (this->ts_max - this->ts_min) / 2;
+    const std::vector<int64_t> cutoffs(seeds.size(), mid);
+
+    for (const auto klt : {KernelLaunchType::NODE_GROUPED, KernelLaunchType::FULL_WALK}) {
+        const auto walks = this->run(*t, seeds, cutoffs,
+            WalkDirection::Backward_In_Time, RandomPickerType::ExponentialIndex, klt);
+        expect_every_edge_before_cutoff(walks, cutoffs, NUM_WALKS_PER_NODE);
+        EXPECT_GT(total_real_hops(walks), seeds.size())
+            << "cutoff at the temporal midpoint should still admit many walks";
+    }
+}
+
+TYPED_TEST(CutoffWalkTest, ForwardEveryEdgeBeforeCutoff) {
+    auto t = this->trw(/*is_directed=*/true);
+    const std::vector<int> seeds = {109, 41, 15, 7, 88};
+    const int64_t mid = this->ts_min + (this->ts_max - this->ts_min) / 2;
+    const std::vector<int64_t> cutoffs(seeds.size(), mid);
+
+    for (const auto klt : {KernelLaunchType::NODE_GROUPED, KernelLaunchType::FULL_WALK}) {
+        const auto walks = this->run(*t, seeds, cutoffs,
+            WalkDirection::Forward_In_Time, RandomPickerType::ExponentialIndex, klt);
+        // Forward caps EVERY hop below the cutoff.
+        expect_every_edge_before_cutoff(walks, cutoffs, NUM_WALKS_PER_NODE);
+    }
+}
+
+TYPED_TEST(CutoffWalkTest, HeterogeneousPerSeedCutoffs) {
+    auto t = this->trw(/*is_directed=*/true);
+    const std::vector<int> seeds = {109, 109, 109, 41, 15};
+    // Each (possibly repeated) seed position gets its own cutoff, including one
+    // unbounded position to confirm independence.
+    const int64_t q1 = this->ts_min + (this->ts_max - this->ts_min) / 4;
+    const int64_t q2 = this->ts_min + (this->ts_max - this->ts_min) / 2;
+    const int64_t q3 = this->ts_min + 3 * (this->ts_max - this->ts_min) / 4;
+    const std::vector<int64_t> cutoffs = {q1, q2, NO_WALK_CUTOFF, q3, q2};
+
+    for (const auto klt : {KernelLaunchType::NODE_GROUPED, KernelLaunchType::FULL_WALK}) {
+        const auto walks = this->run(*t, seeds, cutoffs,
+            WalkDirection::Backward_In_Time, RandomPickerType::ExponentialWeight, klt);
+        expect_every_edge_before_cutoff(walks, cutoffs, NUM_WALKS_PER_NODE);
+    }
+}
+
+TYPED_TEST(CutoffWalkTest, CutoffBelowAllProducesEmptyWalks) {
+    auto t = this->trw(/*is_directed=*/true);
+    const std::vector<int> seeds = {109, 41, 15};
+    // Exclusive bound at the global minimum ⇒ no edge qualifies for any seed.
+    const std::vector<int64_t> cutoffs(seeds.size(), this->ts_min);
+
+    for (const auto klt : {KernelLaunchType::NODE_GROUPED, KernelLaunchType::FULL_WALK}) {
+        const auto walks = this->run(*t, seeds, cutoffs,
+            WalkDirection::Backward_In_Time, RandomPickerType::Uniform, klt);
+        EXPECT_EQ(total_real_hops(walks), 0u)
+            << "no walk should produce a hop when the cutoff is at/below ts_min";
+    }
+}
+
+TYPED_TEST(CutoffWalkTest, CutoffAboveAllEqualsUnbounded) {
+    auto t = this->trw(/*is_directed=*/true);
+    const std::vector<int> seeds = {109, 41, 15, 7};
+    const std::vector<int64_t> cutoffs(seeds.size(), this->ts_max + 1);
+
+    // A cutoff above every edge excludes nothing. The selector tests already
+    // prove "cutoff above max is a no-op" deterministically on both backends;
+    // here we check it end-to-end. The GPU path (Philox seeded by global_seed)
+    // is reproducible across calls, so the bounded-above walks must match the
+    // unbounded walks bit-for-bit. The CPU rand source is seeded per call
+    // (non-deterministic), so there we only assert the run stays productive.
+    for (const auto dir : {WalkDirection::Backward_In_Time, WalkDirection::Forward_In_Time}) {
+        for (const auto klt : {KernelLaunchType::NODE_GROUPED, KernelLaunchType::FULL_WALK}) {
+            const auto bounded = this->run(*t, seeds, cutoffs, dir, RandomPickerType::ExponentialIndex, klt);
+            if constexpr (TypeParam::value) {
+                const auto unbounded = this->run(*t, seeds, {}, dir, RandomPickerType::ExponentialIndex, klt);
+                expect_walks_bit_identical(bounded, unbounded);
+            } else {
+                EXPECT_GT(total_real_hops(bounded), seeds.size());
+            }
+        }
+    }
+}
+
+TYPED_TEST(CutoffWalkTest, UndirectedBackwardRespectsCutoff) {
+    auto t = this->trw(/*is_directed=*/false);
+    const std::vector<int> seeds = {109, 41, 15};
+    const int64_t mid = this->ts_min + (this->ts_max - this->ts_min) / 2;
+    const std::vector<int64_t> cutoffs(seeds.size(), mid);
+
+    for (const auto klt : {KernelLaunchType::NODE_GROUPED, KernelLaunchType::FULL_WALK}) {
+        const auto walks = this->run(*t, seeds, cutoffs,
+            WalkDirection::Backward_In_Time, RandomPickerType::ExponentialWeight, klt);
+        expect_every_edge_before_cutoff(walks, cutoffs, NUM_WALKS_PER_NODE);
+    }
+}
+
+// =====================================================================
+// Layer 3 — cross-kernel parity (all kernels honour the cutoff)
+// =====================================================================
+
+template<typename T>
+class CutoffParityTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        sample_edges = read_edges_from_csv(sample_data_path());
+        for (const auto& [u, v, ts] : sample_edges) ts_max = std::max(ts_max, ts);
+    }
+    std::unique_ptr<TemporalRandomWalk> trw() const {
+        auto t = make_trw(T::value, /*is_directed=*/true);
+        t->add_multiple_edges(sample_edges);
+        return t;
+    }
+    std::vector<std::tuple<int, int, int64_t>> sample_edges;
+    int64_t ts_max = 0;
+};
+
+TYPED_TEST_SUITE(CutoffParityTest, GPU_USAGE_TYPES);
+
+// The hub seed (highest degree) forces the NODE_GROUPED coop block/warp tiers;
+// both they and FULL_WALK must honour the cutoff at step 0 and beyond.
+TYPED_TEST(CutoffParityTest, AllKernelsHonourCutoffOnHubSeed) {
+    auto t = this->trw();
+    const std::vector<int> seeds = {109};  // 1346 edges → coop tiers
+    const int64_t cutoff = this->ts_max / 2;
+    const std::vector<int64_t> cutoffs(seeds.size(), cutoff);
+
+    for (const auto dir : {WalkDirection::Backward_In_Time, WalkDirection::Forward_In_Time}) {
+        for (const auto klt : {KernelLaunchType::NODE_GROUPED,
+                               KernelLaunchType::NODE_GROUPED_GLOBAL_ONLY,
+                               KernelLaunchType::FULL_WALK}) {
+            const auto walks = t->get_random_walks_and_times_for_nodes(
+                seeds.data(), seeds.size(), cutoffs.data(),
+                MAX_WALK_LEN, /*walk_bias=*/&kExpWeight, NUM_WALKS_PER_NODE,
+                /*initial_edge_bias=*/nullptr, dir, klt);
+            expect_every_edge_before_cutoff(walks, cutoffs, NUM_WALKS_PER_NODE);
+        }
+    }
+}
+
+// With a cutoff applied, NODE_GROUPED and FULL_WALK must still produce
+// structurally comparable walk populations (same seed, both cutoff-bounded) —
+// not a jammed/empty population on one path only.
+TYPED_TEST(CutoffParityTest, NodeGroupedAndFullWalkBothProductiveUnderCutoff) {
+    auto t = this->trw();
+    const std::vector<int> seeds = {109, 41, 15};
+    const int64_t cutoff = (3 * this->ts_max) / 4;
+    const std::vector<int64_t> cutoffs(seeds.size(), cutoff);
+
+    const auto grouped = t->get_random_walks_and_times_for_nodes(
+        seeds.data(), seeds.size(), cutoffs.data(), MAX_WALK_LEN,
+        &kExpWeight, NUM_WALKS_PER_NODE, nullptr,
+        WalkDirection::Backward_In_Time, KernelLaunchType::NODE_GROUPED);
+    const auto full = t->get_random_walks_and_times_for_nodes(
+        seeds.data(), seeds.size(), cutoffs.data(), MAX_WALK_LEN,
+        &kExpWeight, NUM_WALKS_PER_NODE, nullptr,
+        WalkDirection::Backward_In_Time, KernelLaunchType::FULL_WALK);
+
+    expect_every_edge_before_cutoff(grouped, cutoffs, NUM_WALKS_PER_NODE);
+    expect_every_edge_before_cutoff(full,    cutoffs, NUM_WALKS_PER_NODE);
+
+    const size_t hops_grouped = total_real_hops(grouped);
+    const size_t hops_full    = total_real_hops(full);
+    EXPECT_GT(hops_grouped, seeds.size());
+    EXPECT_GT(hops_full,    seeds.size());
+
+    // Mean walk length within a wide band (Philox streams differ across paths).
+    const double mean_grouped = static_cast<double>(hops_grouped) / grouped.walk_set.num_walks();
+    const double mean_full    = static_cast<double>(hops_full)    / full.walk_set.num_walks();
+    EXPECT_GT(mean_grouped, 0.5 * mean_full);
+    EXPECT_LT(mean_grouped, 2.0 * mean_full);
+}
+
+} // namespace


### PR DESCRIPTION
Add an optional per-seed `cutoff_times` parameter to `get_random_walks_and_times_for_nodes`. A cutoff is an EXCLUSIVE upper bound on edge time: a seed's walk may only traverse edges with timestamp strictly less than its cutoff. For backward walks this binds the start edge (later hops are already earlier, by monotonicity); for forward walks it caps every hop. NO_WALK_CUTOFF (-1) = unbounded.

One concept threaded uniformly through every execution path — CPU `_std`, FULL_WALK, and NODE_GROUPED (solo + coop warp/block tiers):

- edge_selectors: the cutoff is a universal exclusive upper bound that trims the valid timestamp-group slice in both filter implementations (the shared `filter_valid_groups_by_timestamp_slice` and the inlined device search). Backward folds it into its existing upper bound; forward adds an upper-bound trim. Pickers are unchanged (they already consume a [begin,end) slice). No-cutoff paths pay one comparison.
- WalkSet: the per-walk cutoff is in-progress walk state (its time horizon), carried in a `cutoffs` buffer the kernels read like `last_ts`/`last_node` — so no kernel/dispatch/scheduler signature churn. Default-filled to NO_WALK_CUTOFF.
- prepopulate_start_slot_kernel is cutoff-aware: a seed whose earliest edge is at/after the cutoff yields a dead start (length-0 walk), matching the CPU / full-walk output exactly (cross-kernel parity).
- core: per-seed cutoffs fan out to per-walk (repeat_elements, now type-generic) and co-shuffle with the node ids via a shared shuffle seed when shuffle_walk_order is on.
- Python: optional `cutoff_times=` int64 array, validated to match seed_nodes length.

Tests (new test/test_walk_cutoff_times.cpp, CPU+GPU TYPED_TEST per CPU_GPU_PAIRING.md): deterministic selector-filter checks, whole-walk properties (every edge < cutoff, heterogeneous per-seed cutoffs, empty/unbounded edge cases), and cross-kernel parity on a hub seed — both directions, all kernels. Full suite 340/340; cutoff suite clean 10x and under compute-sanitizer memcheck 5x (0 leaks, 0 errors).